### PR TITLE
[DRAFT] CLI bugfixes and support for importing presets

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## use isinstance()
-  E721,
-
   ## bare except
   E722,
 

--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## bare except
-  E722,
-
   ## imported but unused
   F401,
 

--- a/.flake8
+++ b/.flake8
@@ -7,9 +7,6 @@ extend-ignore=
   ## assigned but never used
   F841,
 
-  ## end-of-file blank lines
-  W391,
-
   # Ignore formatting issues that a tool like black could automatically address
   ## non-syntax indentation (visual)
   E122, E123, E128, E131,
@@ -25,9 +22,6 @@ extend-ignore=
 
   ## trailing whitespace, blank line contains whitespace
   W291, W293,
-
-  ## line breaks around binary operators
-  W503, W504
 
   ## line length
   E501,

--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## imported but unused
-  F401,
-
   ## assigned but never used
   F841,
 

--- a/.github/workflows/flake-pytest.yaml
+++ b/.github/workflows/flake-pytest.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: Test with pytest
         run: |
           cd sourcefiles
-          pytest
+          pytest --cov

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
 [tool.black]
 line-length = 119
 skip_string_normalization = true
+
+[tool.mypy]
+disable_error_code = "annotation-unchecked"
+ignore_missing_imports = true
+files = [
+  "sourcefiles/arguments.py",
+  "sourcefiles/charrando.py",
+  "sourcefiles/jotjson.py",
+  "sourcefiles/mystery.py",
+  "sourcefiles/randosettings.py",
+  "sourcefiles/techdamagerando.py",
+  "sourcefiles/tests/**/*.py"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,13 @@ skip_string_normalization = true
 [tool.mypy]
 disable_error_code = "annotation-unchecked"
 ignore_missing_imports = true
-files = [
-  "sourcefiles/arguments.py",
-  "sourcefiles/charrando.py",
-  "sourcefiles/jotjson.py",
-  "sourcefiles/mystery.py",
-  "sourcefiles/randosettings.py",
-  "sourcefiles/techdamagerando.py",
-  "sourcefiles/tests/**/*.py"
+exclude = [
+  # Some errors on types from tk/ttk in randomizergui.py
+  "^sourcefiles/randomizergui.py",
+
+  # Need to update some type defintions/Optionals in treasures files
+  "^sourcefiles/treasures/",
+
+  # Vanilla Rando code has some missing attributes, might be actual typos/bugs
+  "^sourcefiles/vanillarando/"
 ]

--- a/sourcefiles/.coveragerc
+++ b/sourcefiles/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = True
+omit =
+    # omit cached files
+    __pycache__/*
+    .pytest_cache/*
+
+[report]
+exclude_also =
+    # don't complain if tests don't hit defensive code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain about abstract methods, they aren't run
+    @(abc\.)?abstractmethod

--- a/sourcefiles/.coveragerc
+++ b/sourcefiles/.coveragerc
@@ -13,3 +13,6 @@ exclude_also =
 
     # don't complain about abstract methods, they aren't run
     @(abc\.)?abstractmethod
+
+    # don't complain about type-checking only code
+    if.*TYPE_CHECKING

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -554,6 +554,11 @@ class Argument:
         self.name = name
         self.options = options
 
+    @property
+    def arg(self) -> str:
+        longname = next(name for name in self.name if name.startswith('--'))
+        return longname.lstrip('-').replace('-', '_')
+
 
 class ArgumentGroup(Protocol):
     '''Protocol for building argparse argument groups and attaching to parser.'''

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -303,15 +303,6 @@ class FlagsAdapter(SettingsAdapter):
     _field: str
 
     @classmethod
-    def get(cls, arg: str) -> SettingsFlags:
-        '''Get Flag associated with specified argparse argument.'''
-        for flag, entry in _flag_entry_dict.items():
-            if cls._flag_to_arg(entry) == arg:
-                return flag
-        else:
-            raise KeyError(f"No flag associated with '{arg}'")
-
-    @classmethod
     def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None):
         if init is None:
             if 'preset' in args:

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -5,6 +5,7 @@ import functools
 import operator
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Iterable, Mapping, Optional, Protocol, Union, Type
 
 import ctstrings
@@ -444,11 +445,14 @@ def add_generation_options(parser: argparse.ArgumentParser):
     gen_group.add_argument(
         "--input-file", "-i",
         required=True,
-        help="path to Chrono Trigger (U) rom")
+        help="path to Chrono Trigger (U) rom",
+        type=Path
+    )
 
     gen_group.add_argument(
         "--output-path", "-o",
-        help="path to output directory (default same as input)"
+        help="path to output directory (default same as input)",
+        type=Path
     )
 
     gen_group.add_argument(

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -217,7 +217,7 @@ class ArgumentAdapter(SettingsAdapter):
     _cls: Type[rset.StrIntEnum]
 
     @classmethod
-    def to_setting(cls, args: argparse.Namespace) -> rset.StrIntEnum:
+    def to_setting(cls, args: argparse.Namespace):
         '''Get coerced setting from args or default.'''
         if cls._arg in args:
             choice = getattr(args, cls._arg)
@@ -286,7 +286,7 @@ class FlagsAdapter(SettingsAdapter):
             raise KeyError(f"No flag associated with '{arg}'")
 
     @classmethod
-    def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None) -> SettingsFlags:
+    def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None):
         if init is None:
             init = cls._cls(0)
         flags = (

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -6,7 +6,7 @@ import operator
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Generator, Iterable, Mapping, Optional, Protocol, Union, Tuple, Type
+from typing import Any, Dict, List, Generator, Mapping, Optional, Protocol, Union, Tuple, Type
 
 import ctstrings
 import ctoptions
@@ -14,7 +14,7 @@ import objectivehints as obhint
 import randosettings as rset
 
 from ctenums import CharID
-from randosettings import CharSettings, Difficulty, TechOrder, ShopPrices
+from randosettings import Difficulty, TechOrder, ShopPrices
 from randosettings import GameFlags as GF, GameMode as GM, CosmeticFlags as CF
 
 SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
@@ -182,22 +182,6 @@ _flag_entry_dict: Dict[SettingsFlags, FlagEntry] = {
         "disable most flashing effects"
     )
 }
-
-#flag, name, default
-_mystery_flag_prob_entries = [
-    (GF.TAB_TREASURES, "flag_tab_treasures", 0.10),
-    (GF.UNLOCKED_MAGIC, "flag_unlocked_magic", 0.50),
-    (GF.BUCKET_LIST, "flag_bucket_list", 0.15),
-    (GF.CHRONOSANITY, "flag_chronosanity", 0.30),
-    (GF.BOSS_RANDO, "flag_boss_rando", 0.50),
-    (GF.BOSS_SCALE, "flag_boss_scaling", 0.30),
-    (GF.LOCKED_CHARS, "flag_locked_chars", 0.25),
-    (GF.CHAR_RANDO, "flag_char_rando", 0.5),
-    (GF.DUPLICATE_CHARS, "flag_duplicate_chars", 0.25),
-    (GF.EPOCH_FAIL, "flag_epoch_fail", 0.50),
-    (GF.GEAR_RANDO, "flag_gear_rando", 0.25),
-    (GF.HEALING_ITEM_RANDO, "flag_heal_rando", 0.25),
-]
 
 
 # Adapters and Settings ######################################################
@@ -515,47 +499,11 @@ class CharNamesAdapter(SettingsAdapter):
         return [getattr(args, f"{name.lower()}_name", name) for name in rset.CharSettings.default_names()]
 
 
-def add_flags_to_parser(
-        group_text: Optional[str],
-        flag_list: Iterable[GF | CF],
-        parser: argparse.ArgumentParser):
-
-    add_target: Union[argparse.ArgumentParser, argparse._ArgumentGroup]
-
-    if group_text is None:
-        add_target = parser
-    else:
-        group = parser.add_argument_group(group_text)
-        add_target = group
-
-    for flag in flag_list:
-        flag_entry = _flag_entry_dict[flag]
-        add_args: Iterable[str]
-        if flag_entry.short_name is None:
-            add_args = (flag_entry.name,)
-        else:
-            add_args = (flag_entry.name, flag_entry.short_name)
-        add_target.add_argument(
-            *add_args,
-            help=flag_entry.help_text,
-            action="store_true"
-        )
-
-# https://stackoverflow.com/questions/3853722/
-# how-to-insert-newlines-on-argparse-help-text
-class SmartFormatter(argparse.HelpFormatter):
-
-    def _split_lines(self, text, width):
-        if text.startswith('R|'):
-            return text[2:].splitlines()
-        # this is the RawTextHelpFormatter._split_lines
-        return argparse.HelpFormatter._split_lines(self, text, width)
-
-
 def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     '''Convert result of argparse to settings object.'''
     ret_set = rset.Settings()
-    ret_set.seed = args.seed
+    if 'seed' in args:
+        ret_set.seed = args.seed
     ret_set.game_mode = GameModeAdapter.to_setting(args)
     ret_set.gameflags = GameFlagsAdapter.to_setting(args)
     ret_set.initial_flags = copy.deepcopy(ret_set.gameflags)
@@ -573,494 +521,494 @@ def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     return ret_set
 
 
-def add_generation_options(parser: argparse.ArgumentParser):
+# Arguments and Parser #######################################################
 
-    gen_group = parser.add_argument_group("Generation options")
+class Argument:
+    '''Container for argparse argument for use with ArgumentGroup classes.
 
-    gen_group.add_argument(
-        "--input-file", "-i",
-        required=True,
-        help="path to Chrono Trigger (U) rom",
-        type=Path
-    )
+    Sets most arguments to use argparse.SUPPRESS default, meaning unless explicitly
+    passed on CLI, will not end up in argparse.Namespace. Code within SettingsAdapter
+    checks for this, and when suppressed, does not override the default values
+    assigned when randosettings.Settings is initialized. This prevents needing to
+    double set default values in this file and elsewhere and prevents such regressions.
+    '''
+    name: Tuple[str, ...]
+    options: Dict[str, Any]
 
-    gen_group.add_argument(
-        "--output-path", "-o",
-        help="path to output directory (default same as input)",
-        type=Path
-    )
-
-    gen_group.add_argument(
-        "--seed",
-        help="seed for generation (not website share id)"
-    )
-
-    gen_group.add_argument(
-        "--spoilers",
-        help="generate spoilers with the randomized rom.",
-        action="store_true"
-    )
-
-    gen_group.add_argument(
-        "--json-spoilers",
-        help="generate json spoilers with the randomized rom.",
-        action="store_true"
-    )
+    def __init__(self, *name: str, **options):
+        if not options.get('required') and 'default' not in options:
+            options['default'] = argparse.SUPPRESS
+        self.name = name
+        self.options = options
 
 
-def get_parser():
-    parser = argparse.ArgumentParser(formatter_class=SmartFormatter)
+class ArgumentGroup(Protocol):
+    '''Protocol for building argparse argument groups and attaching to parser.'''
 
-    add_generation_options(parser)
+    # argument group title and description
+    _title: str
+    _desc: Optional[str] = None
 
-    # arguments with a default of "argparse.SUPPRESS", when explicitly specified
-    # on the CLI, will override any other value (e.g. from a preset file)
-    parser.add_argument(
-        "--mode",
-        choices=['std', 'lw', 'ia', 'loc', 'van'],
-        help="R|"
-        "the basic game mode\n"
-        " std: standard Jets of Time (default)\n"
-        "  lw: lost worlds\n"
-        "  ia: ice age\n"
-        " loc: legacy of cyrus\n"
-        " van: vanilla rando",
-        default=argparse.SUPPRESS,
-        type=str.lower
-    )
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        '''Yield arguments from group.'''
+        raise NotImplementedError(f"Missing .arguments definition for '{cls}'.")
 
-    parser.add_argument(
-        "--item-difficulty", "-idiff",
-        help="controls quality of treasure, drops, and starting gold "
-        "(default: normal)",
-        choices=['easy','normal', 'hard'],
-        default=argparse.SUPPRESS,
-        type=str.lower
-    )
+    @classmethod
+    def add_to_parser(cls, parser: argparse.ArgumentParser) -> argparse._ArgumentGroup:
+        '''Create argument group, add all arguments to it, and attach to parser.'''
+        group = parser.add_argument_group(cls._title, description=cls._desc)
+        for arg in cls.arguments():
+            group.add_argument(*arg.name, **arg.options)
+        return group
 
-    parser.add_argument(
-        "--enemy-difficulty", "-ediff",
-        help="controls strength of enemies and xp/tp rewards "
-        "(default: normal)",
-        choices=['normal', 'hard'],
-        default=argparse.SUPPRESS,
-        type=str.lower
-    )
 
-    parser.add_argument(
-        "--tech-order",
-        help="R|"
-        "controls the order in which characters learn techs\n"
-        "  normal - vanilla tech order\n"
-        "balanced - random but biased towards better techs later\n"
-        "  random - fully random (default)",
-        choices=['normal', 'balanced', 'random'],
-        default=argparse.SUPPRESS,
-        type=str.lower
-    )
+class FlagsArgumentGroup(ArgumentGroup):
+    '''Implemention of ArgumentGroup for arguments related to Flag options.'''
 
-    parser.add_argument(
-        "--shop-prices",
-        help="R|"
-        "controls the prices in shops\n"
-        "    normal - standard prices (default)\n"
-        "    random - fully random prices\n"
-        "mostrandom - random except for staple consumables\n"
-        "      free - all items cost 1G",
-        choices=['normal', 'random', 'mostrandom', 'free'],
-        default=argparse.SUPPRESS,
-        type=str.lower
-    )
+    # list of flags which should have an argument created (one per flag)
+    _flags: List[SettingsFlags]
 
-    add_flags_to_parser(
-        'Basic Flags',
-        (GF.FIX_GLITCH, GF.BOSS_SCALE, GF.ZEAL_END, GF.FAST_PENDANT,
-         GF.LOCKED_CHARS, GF.UNLOCKED_MAGIC, GF.CHRONOSANITY,
-         GF.TAB_TREASURES, GF.BOSS_RANDO, GF.CHAR_RANDO,
-         GF.MYSTERY, GF.HEALING_ITEM_RANDO, GF.GEAR_RANDO,
-         GF.EPOCH_FAIL), parser
-    )
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        for flag in cls._flags:
+            flag_entry = _flag_entry_dict[flag]
+            name = [flag_entry.name]
+            if flag_entry.short_name is not None:
+                name.append(flag_entry.short_name)
+            yield Argument(*name, help=flag_entry.help_text, action='store_true')
 
-    add_flags_to_parser(
-        'QoL Flags',
-        (GF.FAST_TABS, GF.VISIBLE_HEALTH, GF.BOSS_SIGHTSCOPE,
-         GF.FREE_MENU_GLITCH),
-        parser
-    )
 
-    add_flags_to_parser(
-        "Extra Flags",
-        (GF.STARTERS_SUFFICIENT, GF.USE_ANTILIFE, GF.TACKLE_EFFECTS_ON,
-         GF.BUCKET_LIST, GF.TECH_DAMAGE_RANDO),
-        parser
-    )
+class BasicFlagsAG(FlagsArgumentGroup):
+    _title = 'Basic Flags'
+    _flags = [
+        GF.FIX_GLITCH, GF.BOSS_SCALE, GF.ZEAL_END, GF.FAST_PENDANT, GF.LOCKED_CHARS, GF.UNLOCKED_MAGIC,
+        GF.CHRONOSANITY, GF.TAB_TREASURES, GF.BOSS_RANDO, GF.CHAR_RANDO, GF.MYSTERY, GF.HEALING_ITEM_RANDO,
+        GF.GEAR_RANDO, GF.EPOCH_FAIL
+    ]
 
-    add_flags_to_parser(
-        "Logic Tweak Flags that add a KI",
-        (GF.RESTORE_JOHNNY_RACE, GF.RESTORE_TOOLS),
-        parser
-    )
 
-    add_flags_to_parser(
-        "Logic Tweak Flags that add/remove a KI Spot",
-        (GF.ADD_BEKKLER_SPOT, GF.ADD_OZZIE_SPOT, GF.ADD_RACELOG_SPOT,
-         GF.ADD_CYRUS_SPOT, GF.VANILLA_ROBO_RIBBON, GF.REMOVE_BLACK_OMEN_SPOT),
-        parser
-    )
+class QoLFlagsAG(FlagsArgumentGroup):
+    _title = 'QoL Flags'
+    _flags = [GF.FAST_TABS, GF.VISIBLE_HEALTH, GF.BOSS_SIGHTSCOPE, GF.FREE_MENU_GLITCH]
 
-    add_flags_to_parser(
-        "Logic Flags that are KI/KI Spot Neutral",
-        (GF.UNLOCKED_SKYGATES, GF.ADD_SUNKEEP_SPOT, GF.SPLIT_ARRIS_DOME,
-         GF.VANILLA_DESERT, GF.ROCKSANITY),
-        parser
-    )
 
-    bucket_options = parser.add_argument_group(
-        "--bucket-list [-k] options"
-    )
+class ExtraFlagsAG(FlagsArgumentGroup):
+    _title = 'Extra Flags'
+    _flags = [GF.STARTERS_SUFFICIENT, GF.USE_ANTILIFE, GF.TACKLE_EFFECTS_ON, GF.BUCKET_LIST, GF.TECH_DAMAGE_RANDO]
 
-    bucket_options.add_argument(
-        "--bucket-objective-count",
-        help="Number of objectives to use.",
-        type=int,
-        default=5
-    )
 
-    bucket_options.add_argument(
-        "--bucket-objective-needed-count",
-        help="Number of objectives needed to meet goal.",
-        type=int,
-        default=4
-    )
+class LogicKIFlagsAG(FlagsArgumentGroup):
+    _title = 'Logic Tweak Flags that add a KI'
+    _flags = [GF.RESTORE_JOHNNY_RACE, GF.RESTORE_TOOLS]
 
-    bucket_options.add_argument(
-        "--bucket-objectives-win",
-        help="Objectives win game instead of unlocking bucket.",
-        action="store_true"
-    )
 
-    bucket_options.add_argument(
-        "--bucket-disable-other-go",
-        help="The only way to win is through the bucket.",
-        action="store_true"
-    )
+class LogicSpotFlagsAG(FlagsArgumentGroup):
+    _title = 'Logic Tweak Flags that add/remove a KI Spot'
+    _flags = [
+        GF.ADD_BEKKLER_SPOT, GF.ADD_OZZIE_SPOT, GF.ADD_RACELOG_SPOT, GF.ADD_CYRUS_SPOT, GF.VANILLA_ROBO_RIBBON,
+        GF.REMOVE_BLACK_OMEN_SPOT
+    ]
 
-    def check_bucket_objective(hint: str) -> str:
+
+class LogicNeutralFlagsAG(FlagsArgumentGroup):
+    _title = 'Logic Flags that are KI/KI Spot Neutral'
+    _flags = [GF.UNLOCKED_SKYGATES, GF.ADD_SUNKEEP_SPOT, GF.SPLIT_ARRIS_DOME, GF.VANILLA_DESERT, GF.ROCKSANITY]
+
+
+class CosmeticsFlagsAG(FlagsArgumentGroup):
+    _title = 'Cosmetic Flags'
+    _desc = 'Have no effect on randomization.'
+    _flags = [CF.AUTORUN, CF.DEATH_PEAK_ALT_MUSIC, CF.ZENAN_ALT_MUSIC, CF.QUIET_MODE, CF.REDUCE_FLASH]
+
+
+class BucketListAG(ArgumentGroup):
+    _title = '--bucket-list [-k] options'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        bset = rset.BucketSettings()
+        yield Argument(
+            '--bucket-objective-count',
+            help=f"Number of objectives to use. [{bset.num_objectives}]",
+            type=int,
+        )
+        yield Argument(
+            '--bucket-objective-needed-count',
+            help=f"Number of objectives needed to meet goal. [{bset.num_objectives_needed}]",
+            type=int,
+        )
+        yield Argument(
+            '--bucket-objectives-win',
+            help=f"Objectives win game instead of unlocking bucket. [{bset.objectives_win}]",
+            action='store_true',
+        )
+        yield Argument(
+            '--bucket-disable-other-go',
+            help=f"The only way to win is through the bucket. [{bset.disable_other_go_modes}]",
+            action='store_true',
+        )
+        for obj in range(1, 9):
+            yield Argument(f"--bucket-objective{obj}", f"-obj{obj}", type=cls._check_bucket_objective)
+
+    @staticmethod
+    def _check_bucket_objective(hint: str) -> str:
         valid, msg = obhint.is_hint_valid(hint)
         if not valid:
             raise argparse.ArgumentTypeError(f"Invalid bucket objective: '{msg}'")
         return hint
 
-    for obj_ind in range(1, 9):
-        bucket_options.add_argument(
-            f"--bucket-objective{obj_ind}", f"-obj{obj_ind}",
-            default="",
-            type=check_bucket_objective
+
+class BossRandoAG(ArgumentGroup):
+    _title = '-ro Options'
+    _desc = 'These options are only valid when --boss-randomization [-ro] is set'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        yield Argument(
+            '--boss-spot-hp',
+            help='boss HP is set to match the vanilla boss HP in each spot',
+            action='store_true',
         )
 
-    # Boss Rando Options
-    ro_options = parser.add_argument_group(
-        "-ro Options",
-        "These options are only valid when --boss-randomization [-ro] is set"
-    )
-    ro_options.add_argument(
-        "--boss-spot-hp",
-        help="boss HP is set to match the vanilla boss HP in each spot",
-        action="store_true"
-    )
 
-    # Character Rando Options
-    rc_options = parser.add_argument_group(
-        "-rc Options",
-        "These options are only valid when --char-rando [-rc] "
-        "is set"
-    )
+class CharNamesAG(ArgumentGroup):
+    _title = 'Character Names'
 
-    rc_options.add_argument(
-        "--duplicate-characters", "-dc",
-        help="Allow multiple copies of a character to be present in a seed.",
-        action="store_true"
-    )
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        for char_name in rset.CharSettings.default_names():
+            yield Argument(f"--{char_name.lower()}-name", help=f"[{char_name}]", type=cls._verify_name)
 
-    rc_options.add_argument(
-        "--duplicate-techs",
-        help="Allow duplicate characters to perform dual techs together.",
-        action="store_true"
-    )
-
-    rc_options.add_argument(
-        "--crono-choices",
-        help="The characters Crono is allowed to be assigned. For example, "
-        "--crono-choices \"lucca robo\" would allow Crono to be assigned to "
-        "either Lucca or Robo.  If the list is preceded with \"not\" "
-        "(e.g. not lucca ayla) then all except the listed characters will be "
-        "allowed.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--marle-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--lucca-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--robo-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--frog-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--ayla-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    rc_options.add_argument(
-        "--magus-choices",
-        help="Same as --crono-choices.",
-        default="all"
-    )
-
-    # Tab Options
-    tab_options = parser.add_argument_group(
-        "Tab Settings"
-    )
-
-    tab_options.add_argument(
-        "--min-power-tab",
-        help="The minimum value a power tab can increase power by (default 2)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    tab_options.add_argument(
-        "--max-power-tab",
-        help="The maximum value a power tab can increase power by (default 4)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    tab_options.add_argument(
-        "--min-magic-tab",
-        help="The minimum value a magic tab can increase power by (default 1)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    tab_options.add_argument(
-        "--max-magic-tab",
-        help="The maximum value a magic tab can increase power by (default 3)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    tab_options.add_argument(
-        "--min-speed-tab",
-        help="The minimum value a speed tab can increase power by (default 1)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    tab_options.add_argument(
-        "--max-speed-tab",
-        help="The maximum value a speed tab can increase power by (default 1)",
-        default=1,
-        type=int,
-        choices=range(1, 10)
-    )
-
-    def check_non_neg(value) -> int:
-        ivalue = int(value)
-        if ivalue < 0:
-            raise argparse.ArgumentTypeError(
-                "%s is an invalide negative frequency" % value
-            )
-
-        return ivalue
-
-    def fill_mystery_freq_group(freq_dict, arg_group: argparse._ArgumentGroup):
-        for string, rel_freq in freq_dict:
-            arg_group.add_argument(
-                "--mystery_"+string,
-                type=check_non_neg,
-                help="default: %d" % rel_freq,
-                default=rel_freq,
-            )
-
-    mystery_modes = parser.add_argument_group(
-        "Mystery Game Mode relative frequency (only if --mystery is set). "
-        "Set the relative frequency with which "
-        "each game mode can appear.  These must be non-negative integers." 
-    )
-
-    mystery_mode_freq_entries = [
-        ("mode_std", 1), ("mode_lw", 1), ("mode_loc", 1),
-        ("mode_ia", 1), ("mode_van", 0),
-    ]
-
-    fill_mystery_freq_group(mystery_mode_freq_entries, mystery_modes)
-
-    mystery_item_diff = parser.add_argument_group(
-        "Mystery Item Difficulty relative frequency (only with --mystery)"
-    )
-
-    mystery_idiff_freq_entries = [
-        ("item_easy", 15),
-        ("item_norm", 75),
-        ("item_hard", 15),
-    ]
-
-    fill_mystery_freq_group(mystery_idiff_freq_entries, mystery_item_diff)
-
-    mystery_enemy_diff = parser.add_argument_group(
-        "Mystery Enemy Difficulty relative frequency (only with --mystery)"
-    )
-    mystery_ediff_freq_entries = [
-        ("enemy_norm", 75),
-        ("enemy_hard", 25),
-    ]
-
-    fill_mystery_freq_group(mystery_ediff_freq_entries, mystery_enemy_diff)
-
-    mystery_tech_order_freq_entries = [
-        ("tech_norm", 10),
-        ("tech_rand", 80),
-        ("tech_balanced", 10),
-    ]
-
-    mystery_tech_order = parser.add_argument_group(
-        "Mystery Tech Order relative frequency (only with --mystery)"
-    )
-    fill_mystery_freq_group(mystery_tech_order_freq_entries,
-                            mystery_tech_order)
-
-    mystery_price_freq_entries = [
-        ("prices_norm", 70),
-        ("prices_rand", 10),
-        ("prices_mostly_rand", 10),
-        ("prices_free", 10)
-    ]
-    mystery_prices = parser.add_argument_group(
-        "Mystery Shop Price relative frequency (only with --mystery)"
-    )
-
-    fill_mystery_freq_group(mystery_price_freq_entries, mystery_prices)
-
-    mystery_flags = parser.add_argument_group(
-        "Mystery Flags Probabilities.  The chance that a flag will be set in "
-        "the mystery settings.  All flags not listed here will be set as they "
-        "are in the main settings."
-    )
-
-    def check_prob(val) -> float:
-        fval = float(val)
-
-        if not 0 <= fval <= 1:
-            raise argparse.ArgumentTypeError("Probability must be in [0,1]")
-
-        return fval
-
-    for _, flag_str, prob in _mystery_flag_prob_entries:
-        mystery_flags.add_argument(
-            "--mystery_"+flag_str,
-            type=check_prob,
-            default=prob,
-            help="default %0.2f" % prob
-        )
-
-    add_flags_to_parser(
-        "Cosmetic Flags.  Have no effect on randomization.",
-        (CF.AUTORUN, CF.DEATH_PEAK_ALT_MUSIC, CF.ZENAN_ALT_MUSIC,
-         CF.QUIET_MODE, CF.REDUCE_FLASH),
-        parser
-    )
-
-    def verify_name(string: str) -> str:
+    @staticmethod
+    def _verify_name(string: str) -> str:
         if len(string) > 5:
-            raise argparse.ArgumentTypeError(
-                "Name must have length 5 or less.")
-
+            raise argparse.ArgumentTypeError('Name must have length 5 or less.')
         try:
-            ctnamestr = ctstrings.CTNameString.from_string(
-                string, 5)
+            ctnamestr = ctstrings.CTNameString.from_string(string, 5)
         except ctstrings.InvalidSymbolException as exc:
-            raise argparse.ArgumentTypeError(
-                "Invalid symbol: \'" + str(exc) +"'")
-
+            raise argparse.ArgumentTypeError(f"Invalid symbol: '{exc}'")
         return string
 
-    name_group = parser.add_argument_group("Character Names")
-    for char_name in CharSettings.default_names():
-        name_group.add_argument(
-            f"--{char_name.lower()}-name",
-            type=verify_name,
-            default=char_name
+
+class CharRandoAG(ArgumentGroup):
+    _title = '-rc Options'
+    _desc = 'These options are only valid when --char-rando [-rc] is set'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        # TODO: remove defaults and handle in CharSettings class?
+        yield Argument(
+            '--duplicate-characters', '-dc',
+            help='Allow multiple copies of a character to be present in a seed.',
+            action='store_true',
+        )
+        yield Argument(
+            '--duplicate-techs',
+            help='Allow duplicate characters to perform dual techs together.',
+            action='store_true',
+        )
+        yield Argument(
+            '--crono-choices',
+            help='The characters Crono is allowed to be assigned. For example, '
+            '--crono-choices "lucca robo" would allow Crono to be assigned to '
+            'either Lucca or Robo.  If the list is preceded with "not" '
+            '(e.g. not lucca ayla) then all except the listed characters will be '
+            'allowed.',
+            default='all',
+        )
+        for name in rset.CharSettings.default_names()[1:-1]:
+            yield Argument(f"--{name.lower()}-choices", help='Same as --crono-choices.', default='all')
+
+
+class GameOptionsAG(ArgumentGroup):
+    _title = 'Game Options'
+    _desc = ''
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        ct_default = ctoptions.CTOpts()
+
+        menu_opts = (
+            ('--save-menu-cursor', 'save last used page of X-menu'),
+            ('--save-battle-cursor', 'save battle cursor position'),
+            ('--save-skill-cursor-off', 'do not save position in skill/item menu'),
+            ('--skill-item-info-off', 'do not show skill/item descriptions'),
+            ('--consistent-paging', 'page up/down have the same effect in all menus'),
         )
 
-    menu_opts = (
-        ("--save-menu-cursor", "save last used page of X-menu"),
-        ("--save-battle-cursor", "save battle cursor position"),
-        ("--save-skill-cursor-off",
-         "do not save position in skill/item menu"),
-        ("--skill-item-info-off", "do not show skill/item descriptions"),
-        ("--consistent-paging",
-         "page up/down have the same effect in all menus")
-    )
+        for name, desc in menu_opts:
+            default: Any = bool(getattr(ct_default, CTOptsAdapter.get(name)))
+            if name.endswith('-off'):
+                default = not default
+            desc = f"{desc} [{default}]"
+            yield Argument(name, help=desc, action="store_true")
 
-    opts_group = parser.add_argument_group("Game Options")
-    for name, desc in menu_opts:
-        opts_group.add_argument(
-            name, help=desc, action="store_true"
+        plus_one_opts = (
+            ('--battle-speed', 'default battle speed (lower is faster)'),
+            ('--battle-msg-speed', 'default battle message speed (lower is faster)'),
+            ('--background', 'default background'),
+        )
+        for name, desc in plus_one_opts:
+            default = int(getattr(ct_default, CTOptsAdapter.get(name))) + 1
+            desc = f"{desc} [{default}]"
+            yield Argument(name, help=desc, type=int, choices=range(1, 9))
+
+        default = int(getattr(ct_default, CTOptsAdapter.get('battle_gauge_style')))
+        desc = f"default atb gauge style [{default}]"
+        yield Argument('--battle-gauge-style', help=desc, type=int, choices=range(3))
+
+
+class GeneralOptionsAG(ArgumentGroup):
+    _title = 'General options'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        diff_default = str(Difficulty.default()).lower()
+        yield Argument(
+            '--mode',
+            choices=['std', 'lw', 'ia', 'loc', 'van'],
+            help="R|"
+            "the basic game mode\n"
+            " std: standard Jets of Time [default]\n"
+            "  lw: lost worlds\n"
+            "  ia: ice age\n"
+            " loc: legacy of cyrus\n"
+            " van: vanilla rando",
+            type=str.lower,
+        )
+        yield Argument(
+            '--item-difficulty', '-idiff',
+            help=f"controls quality of treasure, drops, and starting gold [{diff_default}]",
+            choices=['easy', 'normal', 'hard'],
+            type=str.lower,
+        )
+        yield Argument(
+            '--enemy-difficulty', '-ediff',
+            help=f"controls strength of enemies and xp/tp rewards [{diff_default}]",
+            choices=['normal', 'hard'],
+            type=str.lower,
+        )
+        yield Argument(
+            '--tech-order',
+            help="R|"
+            "controls the order in which characters learn techs\n"
+            "  normal - vanilla tech order\n"
+            "balanced - random but biased towards better techs later\n"
+            "  random - fully random [default]",
+            choices=['normal', 'balanced', 'random'],
+            type=str.lower,
+        )
+        yield Argument(
+            '--shop-prices',
+            help="R|"
+            "controls the prices in shops\n"
+            "    normal - standard prices [default]\n"
+            "    random - fully random prices\n"
+            "mostrandom - random except for staple consumables\n"
+            "      free - all items cost 1G",
+            choices=['normal', 'random', 'mostrandom', 'free'],
+            type=str.lower,
         )
 
-    opts_group.add_argument(
-        "--battle-speed",
-        help="default battle speed (lower is faster)",
-        type=int,
-        choices=range(1, 9),
-        default=5
+
+class GenerationOptionsAG(ArgumentGroup):
+    _title = 'Generation options'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        yield Argument(
+            '--input-file', '-i',
+            required=True,
+            help='path to Chrono Trigger (U) rom',
+            type=Path,
+        )
+        yield Argument(
+            '--output-path', '-o',
+            help='path to output directory (default same as input)',
+            type=Path,
+        )
+        yield Argument(
+            '--seed',
+            help='seed for generation (not website share id)',
+        )
+        yield Argument(
+            '--spoilers',
+            help='generate spoilers with the randomized rom.',
+            action='store_true',
+        )
+        yield Argument(
+            '--json-spoilers',
+            help='generate json spoilers with the randomized rom.',
+            action='store_true',
+        )
+
+
+class MysterySettingsArgumentGroup(ArgumentGroup):
+    '''Implementation of ArgumentGroup for building arguments for mystery options.'''
+
+    # field from randosettings.MysterySettings to build arguments
+    _field: str
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        ms_default = rset.MysterySettings()
+
+        for arg, key in MysterySettingsAdapter.args(cls._field):
+            flag = f"--{arg.replace('_', '-')}"
+            rel_freq = ms_default[cls._field][key]
+            desc = "[%d]" % rel_freq
+            yield Argument(flag, type=cls._check_non_neg, help=desc)
+
+    @staticmethod
+    def _check_non_neg(value) -> int:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise argparse.ArgumentTypeError(f"Invalid negative frequency: {value}")
+        return ivalue
+
+
+class MysteryModeAG(MysterySettingsArgumentGroup):
+    _title = 'Mystery Game Mode relative frequency (only with --mystery)'
+    _desc = 'Set the relative frequency with which each game mode can appear. These must be non-negative integers.'
+    _field = 'game_mode_freqs'
+
+
+class MysteryItemDiffAG(MysterySettingsArgumentGroup):
+    _title = 'Mystery Item Difficulty relative frequency (only with --mystery)'
+    _field = 'item_difficulty_freqs'
+
+
+class MysteryEnemyDiffAG(MysterySettingsArgumentGroup):
+    _title = 'Mystery Enemy Difficulty relative frequency (only with --mystery)'
+    _field = 'enemy_difficulty_freqs'
+
+
+class MysteryTechOrderAG(MysterySettingsArgumentGroup):
+    _title = 'Mystery Tech Order relative frequency (only with --mystery)'
+    _field = 'tech_order_freqs'
+
+
+class MysteryShopPricesAG(MysterySettingsArgumentGroup):
+    _title = 'Mystery Shop Price relative frequency (only with --mystery)'
+    _field = 'shop_price_freqs'
+
+
+class MysteryFlagsAG(ArgumentGroup):
+    _title = 'Mystery Flags Probabilities (only with --mystery)'
+    _desc = (
+        'The chance that a flag will be set in  the mystery settings. '
+        'All flags not listed here will be set as they are in the main settings.'
     )
 
-    opts_group.add_argument(
-        "--battle-msg-speed",
-        help="default battle message speed (lower is faster)",
-        type=int,
-        choices=range(1, 9),
-        default=5
-    )
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        ms_default = rset.MysterySettings()
 
-    opts_group.add_argument(
-        "--battle-gauge-style",
-        help="default atb gauge style (default 1)",
-        type=int,
-        choices=range(3),
-        default=1
-    )
+        for arg, key in MysterySettingsAdapter.args('flag_prob_dict'):
+            flag = f"--{arg.replace('_', '-')}"
+            prob = ms_default['flag_prob_dict'][key]
+            desc = "[%0.2f]" % prob
+            yield Argument(flag, type=cls._check_prob, help=desc)
 
-    opts_group.add_argument(
-        "--background",
-        help="default background (default 1)",
-        type=int,
-        choices=range(1, 9),
-        default=1
-    )
+    @staticmethod
+    def _check_prob(val) -> float:
+        fval = float(val)
+        if not 0 <= fval <= 1:
+            raise argparse.ArgumentTypeError(f"Invalid probability (must be in [0,1]): {fval}")
+        return fval
 
+
+class TabSettingsAG(ArgumentGroup):
+    _title = 'Tab Settings'
+
+    @classmethod
+    def arguments(cls) -> Generator[Argument, None, None]:
+        tabset = rset.TabSettings()
+        yield Argument(
+            '--min-power-tab',
+            help=f"The minimum value a power tab can increase power by [{tabset.power_min}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        yield Argument(
+            '--max-power-tab',
+            help=f"The maximum value a power tab can increase power by [{tabset.power_max}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        yield Argument(
+            '--min-magic-tab',
+            help=f"The minimum value a magic tab can increase power by [{tabset.magic_min}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        yield Argument(
+            '--max-magic-tab',
+            help=f"The maximum value a magic tab can increase power by [{tabset.magic_max}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        yield Argument(
+            '--min-speed-tab',
+            help=f"The minimum value a speed tab can increase power by [{tabset.speed_min}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        yield Argument(
+            '--max-speed-tab',
+            help=f"The maximum value a speed tab can increase power by [{tabset.speed_max}]",
+            type=int,
+            choices=range(1, 10),
+        )
+        scheme = str(tabset.scheme).lower()
+        yield Argument(
+            '--tab-scheme',
+            help=f"Probability distribution scheme for tabs [{scheme}]",
+            choices=['uniform', 'binomial'],
+        )
+        yield Argument(
+            '--tab-binom-success',
+            help=f"Success probability for tabs (when binomial scheme used) [{tabset.binom_success}]",
+            type=float,
+        )
+
+
+# https://stackoverflow.com/questions/3853722/
+# how-to-insert-newlines-on-argparse-help-text
+class SmartFormatter(argparse.HelpFormatter):
+    def _split_lines(self, text, width):
+        if text.startswith('R|'):
+            return text[2:].splitlines()
+        # this is the RawTextHelpFormatter._split_lines
+        return argparse.HelpFormatter._split_lines(self, text, width)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(formatter_class=SmartFormatter)
+    groups: List[Type[ArgumentGroup]] = [
+        GenerationOptionsAG,
+        GeneralOptionsAG,
+        BasicFlagsAG,
+        BossRandoAG,
+        CharRandoAG,
+        TabSettingsAG,
+        QoLFlagsAG,
+        ExtraFlagsAG,
+        LogicKIFlagsAG,
+        LogicSpotFlagsAG,
+        LogicNeutralFlagsAG,
+        BucketListAG,
+        MysteryModeAG,
+        MysteryItemDiffAG,
+        MysteryEnemyDiffAG,
+        MysteryTechOrderAG,
+        MysteryShopPricesAG,
+        MysteryFlagsAG,
+        CosmeticsFlagsAG,
+        CharNamesAG,
+        GameOptionsAG,
+    ]
+    for ag in groups:
+        ag.add_to_parser(parser)
     return parser

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -842,6 +842,7 @@ class GenerationOptionsAG(ArgumentGroup):
         yield Argument(
             '--output-path', '-o',
             help='path to output directory (default same as input)',
+            default=None,
             type=Path,
         )
         yield Argument(
@@ -851,21 +852,23 @@ class GenerationOptionsAG(ArgumentGroup):
         yield Argument(
             '--spoilers',
             help='generate spoilers with the randomized rom.',
+            default=None,
             action='store_true',
         )
         yield Argument(
             '--json-spoilers',
             help='generate json spoilers with the randomized rom.',
+            default=None,
             action='store_true',
         )
         yield Argument(
             '--preset',
             help='path to preset JSON file from which to load settings',
-            type=cls._load_preset
+            type=cls.load_preset
         )
 
     @classmethod
-    def _load_preset(cls, preset: str) -> rset.Settings:
+    def load_preset(cls, preset: Union[str, Path]) -> rset.Settings:
         try:
             data = rset.Settings.from_preset_file(Path(preset))
         except Exception as ex:
@@ -1013,31 +1016,42 @@ class SmartFormatter(argparse.HelpFormatter):
         return argparse.HelpFormatter._split_lines(self, text, width)
 
 
+# list of all non-cosmetic argument groups affecting seed generation
+# these are selected prior to generation in the web GUI and may be included in a preset
+ALL_GENERATION_AG: List[Type[ArgumentGroup]] = [
+    GeneralOptionsAG,
+    BasicFlagsAG,
+    BossRandoAG,
+    CharRandoAG,
+    TabSettingsAG,
+    QoLFlagsAG,
+    ExtraFlagsAG,
+    LogicKIFlagsAG,
+    LogicSpotFlagsAG,
+    LogicNeutralFlagsAG,
+    BucketListAG,
+    MysteryModeAG,
+    MysteryItemDiffAG,
+    MysteryEnemyDiffAG,
+    MysteryTechOrderAG,
+    MysteryShopPricesAG,
+    MysteryFlagsAG,
+]
+
+# list of all argument groups affectiong cosmetics
+# these can be selected after seed generation in the web GUI and are not included in a preset
+ALL_COSMETIC_AG: List[Type[ArgumentGroup]] = [
+    CosmeticsFlagsAG,
+    CharNamesAG,
+    GameOptionsAG,
+]
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=SmartFormatter)
-    groups: List[Type[ArgumentGroup]] = [
-        GenerationOptionsAG,
-        GeneralOptionsAG,
-        BasicFlagsAG,
-        BossRandoAG,
-        CharRandoAG,
-        TabSettingsAG,
-        QoLFlagsAG,
-        ExtraFlagsAG,
-        LogicKIFlagsAG,
-        LogicSpotFlagsAG,
-        LogicNeutralFlagsAG,
-        BucketListAG,
-        MysteryModeAG,
-        MysteryItemDiffAG,
-        MysteryEnemyDiffAG,
-        MysteryTechOrderAG,
-        MysteryShopPricesAG,
-        MysteryFlagsAG,
-        CosmeticsFlagsAG,
-        CharNamesAG,
-        GameOptionsAG,
-    ]
+    groups: List[Type[ArgumentGroup]] = [GenerationOptionsAG]
+    groups.extend(ALL_GENERATION_AG)
+    groups.extend(ALL_COSMETIC_AG)
     for ag in groups:
         ag.add_to_parser(parser)
     return parser

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -6,7 +6,6 @@ import typing
 
 from dataclasses import dataclass
 
-import ctenums
 import ctstrings
 import ctoptions
 import randosettings as rset

--- a/sourcefiles/asm/assemble.py
+++ b/sourcefiles/asm/assemble.py
@@ -8,7 +8,6 @@ from typing import Union, List
 from asm import instructions as inst
 from asm.instructions import _BranchInstruction, _NormalInstruction
 
-import byteops
 
 Instruction = Union[_BranchInstruction, _NormalInstruction]
 ASMList = List[Union[Instruction, str]]

--- a/sourcefiles/bossrandotypes.py
+++ b/sourcefiles/bossrandotypes.py
@@ -41,6 +41,14 @@ class BossSpotID(enum.Enum):
     PRISON_CATWALKS = enum.auto()
     EPOCH_REBORN = enum.auto()
 
+    @classmethod
+    def get(cls, key: str):
+        for spot, name in _boss_spot_names.items():
+            if key == name:
+                return spot
+        else:
+            raise KeyError(f"No spot matching '{key}'")
+
     def __str__(self):
         return _boss_spot_names[self]
 
@@ -122,9 +130,18 @@ class BossID(enum.Enum):
     ZEAL = enum.auto()
     ZEAL_2 = enum.auto()
 
+    @classmethod
+    def get(cls, key: str):
+        if key == 'Magus (North Cape)':
+            return BossID.MAGUS_NORTH_CAPE
+        if key == 'Nizbel II':
+            return BossID.NIZBEL_2
+        return getattr(cls, key.replace(' ', '_').upper())
+
     def __str__(self):
         if self == BossID.MAGUS_NORTH_CAPE:
             return 'Magus (North Cape)'
+        # TODO: this check seems unnecessary because covered by standard algorithm below?
         if self == BossID.YAKRA_XIII:
             return 'Yakra XIII'
         if self == BossID.NIZBEL_2:

--- a/sourcefiles/bucketfragment.py
+++ b/sourcefiles/bucketfragment.py
@@ -11,13 +11,18 @@ import randoconfig as cfg
 import xpscale
 
 
+# TODO: there are no references to this function in the codebase
+# might be WIP or could be something to remove
 def set_bucket_function(ctrom: CTRom, settings: rset.Settings):
     script_man = ctrom.script_manager
     eot_script = script_man.get_script(ctenums.LocID.END_OF_TIME)
 
     new_eot_script = ctevent.Event.from_flux('./flux/bucket_eot.Flux')
 
-    num_fragments = settings.bucket_settings.needed_fragments
+    # TODO: below is only reference to "needed_fragements" in codebase
+    # not sure what it should default to but that should be updated in randosettings
+    # if this should be used
+    num_fragments = getattr(settings.bucket_settings, 'needed_fragments', 0)
 
     start = new_eot_script.get_function_start(0x09, 1)
     end = new_eot_script.get_function_end(0x09, 1)

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -5,96 +5,14 @@ Module for creating a frame with bucket settings.
 import tkinter as tk
 import typing
 
+from collections import OrderedDict
+
 import objectivehints as oh
 import randosettings as rset
 
 
-# Build a list of preset objective hint strings with the more common random
-# categories at the top
-_objective_preset_dict: dict[str, str] = {
-    'Random': '65:quest_gated, 30:boss_nogo, 15:recruit_gated',
-    'Random Gated Quest': 'quest_gated',
-    'Random Hard Quest': 'quest_late',
-    'Random Go Mode Quest': 'quest_go',
-    'Random Gated Character Recruit': 'recruit_gated',
-    'Random Boss (Includes Go Mode Dungeons)': 'boss_any',
-    'Random Boss from Go Mode Dungeon': 'boss_go',
-    'Random Boss (No Go Mode Dungeons)': 'boss_nogo',
-    'Recruit 3 Characters (Total 5)': 'recruit_3',
-    'Recruit 4 Characters (Total 6)': 'recruit_4',
-    'Recruit 5 Characters (Total 7)': 'recruit_5',
-    'Collect 10 of 20 Fragments': 'collect_fragments_10_10',
-    'Collect 10 of 30 Fragments': 'collect_fragments_10_20',
-    'Collect 3 Rocks': 'collect_rocks_3',
-    'Collect 4 Rocks': 'collect_rocks_4',
-    'Collect 5 Rocks': 'collect_rocks_5',
-    'Forge the Masamune': 'quest_forge',
-    'Charge the Moonstone': 'quest_moonstone',
-    'Trade the Jerky Away': 'quest_jerky',
-    'Defeat the Arris Dome Boss': 'quest_arris',
-    'Visit Cyrus\'s Grave with Frog': 'quest_cyrus',
-    'Defeat the Boss of Death\'s Peak': 'quest_deathpeak',
-    'Defeat the Boss of Denadoro Mountains': 'quest_denadoro',
-    'Gain Epoch Flight': 'quest_epoch',
-    'Defeat the Boss of the Factory Ruins': 'quest_factory',
-    'Defeat the Boss of the Geno Dome': 'quest_geno',
-    'Defeat the Boss of the Giant\'s Claw': 'quest_claw',
-    'Defeat the Boss of Heckran\'s Cave': 'quest_heckran',
-    'Defeat the Boss of the King\'s Trial': 'quest_shard',
-    'Defeat the Boss of Manoria Cathedral': 'quest_cathedral',
-    'Defeat the Boss of Mount Woe': 'quest_woe',
-    'Defeat the Boss of the Pendant Trial': 'quest_pendant',
-    'Defeat the Boss of the Reptite Lair': 'quest_reptite',
-    'Defeat the Boss of the Sun Palace': 'quest_sunpalace',
-    'Defeat the Boss of the Sunken Desert': 'quest_desert',
-    'Defeat the Boss in the Zeal Throneroom': 'quest_zealthrone',
-    'Defeat the Boss of Zenan Bridge': 'quest_zenan',
-    'Defeat the Black Tyrano': 'quest_blacktyrano',
-    'Defeat the Tyrano Lair Midboss': 'quest_tyranomid',
-    'Defeat the Boss in Flea\'s Spot': 'quest_flea',
-    'Defeat the Boss in Slash\'s Spot': 'quest_slash',
-    'Defeat Magus in Magus\'s Castle': 'quest_magus',
-    'Defeat the Boss in the GigaMutant Spot': 'quest_omengiga',
-    'Defeat the Boss in the TerraMutant Spot': 'quest_omenterra',
-    'Defeat the Boss in the ElderSpawn Spot': 'quest_omenelder',
-    'Defeat the Boss in the Twin Golem Spot': 'quest_twinboss',
-    'Beat Johnny in a Race': 'quest_johnny',
-    'Bet on a Fair Race and Win': 'quest_fairrace',
-    'Play the Fair Drinking Game': 'quest_soda',
-    'Defeat AtroposXR': 'boss_atropos',
-    'Defeat DaltonPlus': 'boss_dalton',
-    'Defeat DragonTank': 'boss_dragontank',
-    'Defeat ElderSpawn': 'boss_elderspawn',
-    'Defeat Flea': 'boss_flea',
-    'Defeat Flea Plus': 'boss_fleaplus',
-    'Defeat Giga Gaia': 'boss_gigagaia',
-    'Defeat GigaMutant': 'boss_gigamutant',
-    'Defeat Golem': 'boss_golem',
-    'Defeat Golem Boss': 'boss_golemboss',
-    'Defeat Guardian': 'boss_guardian',
-    'Defeat Heckran': 'boss_heckran',
-    'Defeat LavosSpawn': 'boss_lavosspawn',
-    'Defeat Magus (North Cape)': 'boss_magusnc',
-    'Defeat Masamune': 'boss_masamune',
-    'Defeat Mother Brain': 'boss_motherbrain',
-    'Defeat Mud Imp': 'boss_mudimp',
-    'Defeat Nizbel': 'boss_nizbel',
-    'Defeat Nizbel II': 'boss_nizbel2',
-    'Defeat R-Series': 'boss_rseries',
-    'Defeat Retinite': 'boss_retinite',
-    'Defeat RustTyrano': 'boss_rusttyrano',
-    'Defeat Slash': 'boss_slash',
-    'Defeat Son of Sun': 'boss_sonofsun',
-    'Defeat Super Slash': 'boss_superslash',
-    'Defeat TerraMutant': 'boss_terramutant',
-    # Skip twinboss b/c it's in quests
-    'Defeat Yakra': 'boss_yakra',
-    'Defeat Yakra XIII': 'boss_yakraxiii',
-    'Defeat Zombor': 'boss_zombor'
-}
-
-
 class BucketPage(tk.Frame):
+    _obhint_aliases: OrderedDict[str, str] = oh.get_objective_hint_aliases()
 
     def __init__(self, *args, **kwargs):
         tk.Frame.__init__(self, *args, **kwargs)
@@ -153,7 +71,7 @@ class BucketPage(tk.Frame):
             tk.Label(frame, text=f'Obj {ind+1}:').pack(side=tk.LEFT)
             option = tk.ttk.Combobox(
                 frame,
-                values=list(_objective_preset_dict.keys()),
+                values=list(self._obhint_aliases.keys()),
                 textvariable=self.simple_mode_choices[ind]
             )
 
@@ -240,7 +158,7 @@ class BucketPage(tk.Frame):
         value = event.widget.get()
 
         if value == '':
-            event.widget.configure(values=list(_objective_preset_dict.keys()))
+            event.widget.configure(values=list(self._obhint_aliases.keys()))
         else:
             cur_values = event.widget.cget('values')
             cur_values = [
@@ -250,8 +168,8 @@ class BucketPage(tk.Frame):
             event.widget.configure(values=cur_values)
 
         label = self.simple_mode_hint_labels[index]
-        if value in _objective_preset_dict:
-            label['text'] = _objective_preset_dict[value]
+        if value in self._obhint_aliases:
+            label['text'] = self._obhint_aliases[value]
         else:
             label['text'] = ''
 
@@ -285,8 +203,8 @@ class BucketPage(tk.Frame):
                     break
 
                 value = combobox.get()
-                if value in _objective_preset_dict:
-                    ret.hints[ind] = _objective_preset_dict[value]
+                if value in self._obhint_aliases:
+                    ret.hints[ind] = self._obhint_aliases[value]
                 else:
                     ret.hints[ind] = value
 
@@ -302,7 +220,7 @@ class BucketPage(tk.Frame):
 
         for ind, hint in enumerate(bs.hints):
             match = [
-                (name, code) for name, code in _objective_preset_dict.items()
+                (name, code) for name, code in self._obhint_aliases.items()
                 if code == hint.lower()
             ]
 

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -2,7 +2,6 @@
 Module for creating a frame with bucket settings.
 '''
 
-import dataclasses
 import tkinter as tk
 import typing
 

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -236,7 +236,7 @@ class BucketPage(tk.Frame):
 
     # https://stackoverflow.com/questions/55649709/
     # is-autocomplete-search-feature-available-in-tkinter-combo-box
-    def check_combobox_input(self, event, index: int = None):
+    def check_combobox_input(self, event, index: typing.Optional[int] = None):
         value = event.widget.get()
 
         if value == '':

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -11,20 +11,14 @@ from common import distribution
 import ctenums
 import ctrom
 
-import eventcommand
 from eventcommand import EventCommand as EC, Operation as OP, FuncSync as FS
-
-import eventfunction
 from eventfunction import EventFunction as EF
-
 from maps import locationtypes
 
 import objectivehints as obhint
 import objectivetypes as oty
-
 import randoconfig as cfg
 import randosettings as rset
-
 import xpscale
 
 

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -202,11 +202,11 @@ def add_objectives_to_config(settings: rset.Settings,
                                      objective_pool[ind])
         objectives.append(objective)
 
-        if type(chosen_key) == str:
+        if isinstance(chosen_key, str):
             chosen_key = chosen_key.split('_')[0]
         used_keys.append(chosen_key)
 
-        if type(chosen_key) == ctenums.CharID:
+        if isinstance(chosen_key, ctenums.CharID):
             used_keys.append('recruits')
 
     for objective in objectives:
@@ -228,7 +228,7 @@ def clean_distribution(dist: distribution.Distribution,
     for weight, items in wo_pairs:
         for key in used_keys:
             if key in ('fragments', 'rocks', 'recruits'):
-                str_keys = [x for x in items if type(x) == str]
+                str_keys = [x for x in items if isinstance(x, str)]
                 match_keys = [x for x in str_keys if key in x]
                 for key in match_keys:
                     items.remove(key)
@@ -244,18 +244,18 @@ def clean_distribution(dist: distribution.Distribution,
 def get_obj_from_key(key, settings: rset.Settings,
                      config: cfg.RandoConfig,
                      item_id: ctenums.ItemID):
-    if type(key) == rotypes.BossID:
+    if isinstance(key, rotypes.BossID):
         return oty.get_defeat_boss_obj(key, settings,
                                        config.boss_assign_dict, item_id)
-    if type(key) == oty.QuestID:
+    if isinstance(key, oty.QuestID):
         return oty.get_quest_obj(key, settings, item_id)
-    if type(key) == ctenums.RecruitID:
+    if isinstance(key, ctenums.RecruitID):
         return oty.get_recruit_spot_obj(key, settings,
                                         config.char_assign_dict, item_id)
-    if type(key) == ctenums.CharID:
+    if isinstance(key, ctenums.CharID):
         return oty.get_recruit_char_obj(key, settings,
                                         config.char_assign_dict, item_id)
-    if type(key) == str:
+    if isinstance(key, str):
         parts = key.split('_')
         if parts[0] == 'rocks':
             num_rocks = int(parts[1])

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -128,7 +128,7 @@ def add_objectives_to_config(settings: rset.Settings,
     rem_objs.secondary_stats.is_key_item = True
 
     num_objs = settings.bucket_settings.num_objectives
-    hints = list(settings.bucket_settings.hints)
+    hints = obhint.normalize_objectives_from_hints(settings.bucket_settings.hints)
 
     KeyType = typing.Union[oty.QuestID, ctenums.RecruitID,
                            rotypes.BossID, str]

--- a/sourcefiles/characters/ctpcstats.py
+++ b/sourcefiles/characters/ctpcstats.py
@@ -10,7 +10,6 @@ import itemdata
 import ctenums
 import ctrom
 import cttypes as ctt
-import ctstrings
 
 
 class PCStat(ctenums.StrIntEnum):

--- a/sourcefiles/characters/ctpcstats.py
+++ b/sourcefiles/characters/ctpcstats.py
@@ -354,7 +354,7 @@ class PCStatData:
         self.tech_level = TechLevel(tech_level)
         self.tp_threshholds = TPThresholds(tp_threshholds)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         # Copying from the old statcompute.py
         stats = {
             'max_hp': self.stat_block.max_hp,
@@ -487,9 +487,9 @@ class PCStatsManager:
         else:
             self.xp_thresholds = XPThreshholds(xp_thresholds)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
-            str(k): self.pc_stat_dict[k]._jot_json() for k in ctenums.CharID
+            str(k): self.pc_stat_dict[k].to_jot_json() for k in ctenums.CharID
         }
 
     @classmethod

--- a/sourcefiles/characters/pcrecruit.py
+++ b/sourcefiles/characters/pcrecruit.py
@@ -17,7 +17,7 @@ class RecruitSpot(typing.Protocol):
     held_char: ctenums.CharID
 
     # Still explicitly defining this in implementing classes
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     def write_to_ctrom(self, ct_rom: ctrom.CTRom):
@@ -46,7 +46,7 @@ class CharRecruit(RecruitSpot):
         self.load_obj_id = load_obj_id
         self.recruit_obj_id = recruit_obj_id
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     # This might be poor naming, but the writing goes to the script manager
@@ -130,7 +130,7 @@ class StarterChar:
         self.held_char = held_char
         self.starter_num = starter_num
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     def write_to_ctrom(self, ct_rom: ctrom.CTRom):

--- a/sourcefiles/charassign.py
+++ b/sourcefiles/charassign.py
@@ -2,8 +2,6 @@ import ctenums
 import ctrom
 
 import eventcommand
-import eventfunction
-
 import randoconfig as cfg
 
 from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 import copy
 import random
 
 from itertools import permutations
+from typing import List
 
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
@@ -69,7 +71,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
         if rset.GameFlags.DUPLICATE_CHARS in settings.gameflags:
             for pc_id in CharID:
                 avail_choices = settings.char_choices[int(pc_id)]
-                choices[pc_id] = random.choice(avail_choices)
+                choices[pc_id] = CharID(random.choice(avail_choices))
         # unique chars (default for char rando)
         else:
             all_choices = [p for p in permutations(range(0, 7), r=7)]
@@ -87,7 +89,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
                     'No valid permutation for unique characters based on '
                     'character choices.'
                 )
-            choices = {pc_id: permutation[pc_id] for pc_id in CharID}
+            choices = {pc_id: CharID(permutation[pc_id]) for pc_id in CharID}
 
         # Get Copies of stats
         orig_stats = {
@@ -112,7 +114,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
         # Turn choices back into a list for the rest of the stuff
         choices_list = [choices[CharID(i)] for i in range(7)]
     else:
-        choices_list = list(range(7))
+        choices_list = [CharID(x) for x in list(range(7))]
 
     dup_duals = rset.GameFlags.DUPLICATE_TECHS in settings.gameflags
     config.tech_db = get_reassign_techdb(config.tech_db,
@@ -1380,7 +1382,7 @@ def reassign_pc_magic(from_ind, to_ind, rom, db, magic_thresh):
     # applied when this option is selected
 
 
-def get_reassign_techdb(orig_db, reassign, dup_duals=False):
+def get_reassign_techdb(orig_db, reassign: List[CharID], dup_duals=False):
     # Make a db with the right menu/battle groups but no techs added yet
     new_db = max_expand_empty_db(orig_db, reassign, dup_duals)
 

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -3,7 +3,6 @@ import random
 
 from itertools import permutations
 
-from characters import ctpcstats
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
     update_ptrs, to_rom_ptr

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -3,7 +3,7 @@ import copy
 import random
 
 from itertools import permutations
-from typing import List
+from typing import Dict, List
 
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
@@ -67,10 +67,10 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
     # It was important to do the scaling first so that we know what level
     # and tech level to use when reassigning
     if rset.GameFlags.CHAR_RANDO in settings.gameflags:
-        choices = {}
+        choices: Dict[CharID, CharID] = {}
         if rset.GameFlags.DUPLICATE_CHARS in settings.gameflags:
             for pc_id in CharID:
-                avail_choices = settings.char_choices[int(pc_id)]
+                avail_choices = settings.char_settings.choices[int(pc_id)]
                 choices[pc_id] = CharID(random.choice(avail_choices))
         # unique chars (default for char rando)
         else:
@@ -80,7 +80,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
                 permutation = next(
                     p for p in shuffle
                     if all(
-                        p[pc_id] in settings.char_choices[pc_id]
+                        p[pc_id] in settings.char_settings.choices[pc_id]
                         for pc_id in CharID
                     )
                 )

--- a/sourcefiles/cosmetichacks.py
+++ b/sourcefiles/cosmetichacks.py
@@ -27,9 +27,7 @@ def set_pc_names(
     '''
     Provide names to be used for characters and epoch.
     '''
-    default_names = (
-        'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch'
-    )
+    default_names = rset.CharSettings.default_names()
 
     copy_str = bytearray()
 

--- a/sourcefiles/cosmetichacks.py
+++ b/sourcefiles/cosmetichacks.py
@@ -27,7 +27,7 @@ def set_pc_names(
     '''
     Provide names to be used for characters and epoch.
     '''
-    default_names = rset.CharSettings.default_names()
+    default_names = rset.CharNames.default()
 
     copy_str = bytearray()
 

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -1,12 +1,15 @@
 '''
 Module for preconfiguring in-game options at compile time
 '''
-from typing import Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import byteops
 from ctenums import ActionMap, InputMap
 from ctrom import CTRom
 from ctevent import FSWriteType
+
+if TYPE_CHECKING:
+    import randosettings as rset
 
 class ControllerBinds:
     '''

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -502,6 +502,9 @@ class CTOpts:
         
         rom.seek(0x011483 + 1) # AND #$10
         rom.write(0x20.to_bytes(1, 'little'))
+
+    def to_jot_json(self) -> Dict[str, "rset.JSONPrimitive"]:
+        return {k: v for k, v in self}
         
 
 if __name__ == '__main__':

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -1,7 +1,7 @@
 '''
 Module for preconfiguring in-game options at compile time
 '''
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Mapping, Optional
 
 import byteops
 from ctenums import ActionMap, InputMap
@@ -444,6 +444,9 @@ class CTOpts:
         
         return ret
 
+    def __eq__(self, other) -> bool:
+        return all(getattr(other, key, None) == value for key, value in self)
+
     def __iter__(self):
         
         ret = {
@@ -460,7 +463,6 @@ class CTOpts:
             'battle_gauge_style': self.battle_gauge_style,
             'consistent_paging': self.consistent_paging
         }
-        
 
         return iter(ret.items())
 
@@ -503,7 +505,18 @@ class CTOpts:
         rom.seek(0x011483 + 1) # AND #$10
         rom.write(0x20.to_bytes(1, 'little'))
 
-    def to_jot_json(self) -> Dict[str, "rset.JSONPrimitive"]:
+    @staticmethod
+    def from_jot_json(data: Dict[str, 'rset.JSONPrimitive']) -> 'CTOpts':
+        if not isinstance(data, Mapping):
+            raise TypeError('CTOpts must be a dictionary/mapping.')
+
+        ctopts = CTOpts()
+        for key, value in data.items():
+            if hasattr(ctopts, key):
+                setattr(ctopts, key, value)
+        return ctopts
+
+    def to_jot_json(self) -> Dict[str, 'rset.JSONPrimitive']:
         return {k: v for k, v in self}
         
 

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -95,7 +95,7 @@ class ControllerBinds:
 
         try:
             check = {x: binds[x] for x in ActionMap}
-        except:
+        except KeyError:
             return False
 
         assigned = [y for x, y in check.items()]

--- a/sourcefiles/enemystats.py
+++ b/sourcefiles/enemystats.py
@@ -121,7 +121,7 @@ class EnemyStats:
         self._set_name(ctstrings.CTString(name_bytes))
         self._set_rewards(reward_bytes)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
             'hp': self.hp,
             'level': self.level,

--- a/sourcefiles/itemdata.py
+++ b/sourcefiles/itemdata.py
@@ -1083,7 +1083,7 @@ class Item:
         self.name = bytearray(name_bytes)
         self.desc = bytearray(desc_bytes)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
             'name': self.get_name_as_str(True),
             'desc': self.get_desc_as_str(),
@@ -1554,5 +1554,5 @@ class ItemDB:
 
         # fs.print_blocks()
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {str(x): self.item_dict[x] for x in self.item_dict}

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,5 +1,4 @@
 import json
-import randoconfig as cfg
 import randosettings as rset
 
 class JOTJSONEncoder(json.JSONEncoder):

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -9,10 +9,6 @@ if TYPE_CHECKING:
 DecodedJOTJSON = Dict[str, Union['rset.Settings', 'rset.JSONType']]
 
 class JOTJSONEncoder(json.JSONEncoder):
-    def __init__(self, *args, **kwargs):
-        kwargs['indent'] = kwargs.get('indent', 2)
-        json.JSONEncoder.__init__(self, *args, **kwargs)
-
     def default(self, obj) -> 'rset.JSONType':
         if hasattr(obj, 'to_jot_json'):
             return obj.to_jot_json()

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
 import json
-import randosettings as rset
+from typing import Any, Dict
+
 
 class JOTJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if hasattr(obj, '_jot_json'):
-            return obj._jot_json()
-        elif isinstance(obj, rset.GameFlags):
-            return [str(flag) for flag in rset.GameFlags if flag in obj]
-        elif isinstance(obj, rset.CosmeticFlags):
-            return [str(flag) for flag in rset.CosmeticFlags if flag in obj]
+    def __init__(self, *args, **kwargs):
+        kwargs['indent'] = 2
+        json.JSONEncoder.__init__(self, *args, **kwargs)
+
+    def default(self, obj) -> Dict[str, Any]:
+        if hasattr(obj, 'to_jot_json'):
+            return obj.to_jot_json()
         return json.JSONEncoder.default(self, obj)

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 import json
-from typing import Any, Dict
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import randosettings as rset
 
 
 class JOTJSONEncoder(json.JSONEncoder):
@@ -8,7 +12,7 @@ class JOTJSONEncoder(json.JSONEncoder):
         kwargs['indent'] = 2
         json.JSONEncoder.__init__(self, *args, **kwargs)
 
-    def default(self, obj) -> Dict[str, Any]:
+    def default(self, obj) -> 'rset.JSONType':
         if hasattr(obj, 'to_jot_json'):
             return obj.to_jot_json()
         return json.JSONEncoder.default(self, obj)

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 import json
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
-import randosettings as rset
+if TYPE_CHECKING:
+    import randosettings as rset
 
-DecodedJOTJSON = Dict[str, Union[rset.Settings, rset.JSONType]]
+DecodedJOTJSON = Dict[str, Union['rset.Settings', 'rset.JSONType']]
 
 class JOTJSONEncoder(json.JSONEncoder):
     def __init__(self, *args, **kwargs):
-        kwargs['indent'] = 2
+        kwargs['indent'] = kwargs.get('indent', 2)
         json.JSONEncoder.__init__(self, *args, **kwargs)
 
-    def default(self, obj) -> rset.JSONType:
+    def default(self, obj) -> 'rset.JSONType':
         if hasattr(obj, 'to_jot_json'):
             return obj.to_jot_json()
         return json.JSONEncoder.default(self, obj)
@@ -23,6 +24,9 @@ class JOTJSONDecoder(json.JSONDecoder):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
 
     def object_hook(self, obj: Dict[str, Any]) -> DecodedJOTJSON:
+        # late import to prevent circular import between randosettings and jotjoon
+        import randosettings as rset
+
         # for now, strip out configuration, as not needed for presets
         # in future, if needed, can add decoding for it
         if 'configuration' in obj:

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,18 +1,33 @@
 from __future__ import annotations
 import json
 
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Union
 
-if TYPE_CHECKING:
-    import randosettings as rset
+import randosettings as rset
 
+DecodedJOTJSON = Dict[str, Union[rset.Settings, rset.JSONType]]
 
 class JOTJSONEncoder(json.JSONEncoder):
     def __init__(self, *args, **kwargs):
         kwargs['indent'] = 2
         json.JSONEncoder.__init__(self, *args, **kwargs)
 
-    def default(self, obj) -> 'rset.JSONType':
+    def default(self, obj) -> rset.JSONType:
         if hasattr(obj, 'to_jot_json'):
             return obj.to_jot_json()
         return json.JSONEncoder.default(self, obj)
+
+
+class JOTJSONDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, obj: Dict[str, Any]) -> DecodedJOTJSON:
+        # for now, strip out configuration, as not needed for presets
+        # in future, if needed, can add decoding for it
+        if 'configuration' in obj:
+            obj.pop('configuration')
+        if 'settings' in obj:
+            settings = rset.Settings.from_jot_json(obj['settings'])
+            obj['settings'] = settings
+        return obj

--- a/sourcefiles/logicfactory.py
+++ b/sourcefiles/logicfactory.py
@@ -1,4 +1,3 @@
-import random
 import typing
 from typing import List, Optional, Type
 from math import ceil

--- a/sourcefiles/logictypes.py
+++ b/sourcefiles/logictypes.py
@@ -370,7 +370,7 @@ class Location:
     def __repr__(self):
         return f'<Location.{self.getName()}>'
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {self.getName(): str(self.getKeyItem())}
 
     #
@@ -504,7 +504,7 @@ class LinkedLocation():
         self.location1 = location1
         self.location2 = location2
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {self.getName(): str(self.getKeyItem())}
 
     def getName(self):

--- a/sourcefiles/logicwriter_chronosanity.py
+++ b/sourcefiles/logicwriter_chronosanity.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import random as rand
 
+from typing import List
+
 
 # jets of time libraries
 import logicfactory
@@ -20,7 +22,7 @@ import randosettings as rset
 #
 
 # Script variables
-locationGroups = []
+locationGroups: List[logictypes.LocationGroup] = []
 
 
 #
@@ -30,7 +32,7 @@ locationGroups = []
 #
 # return: List of all available LocationGroups
 #
-def getAvailableLocations(game: logictypes.Game) -> list[logictypes.Location]:
+def getAvailableLocations(game: logictypes.Game) -> List[logictypes.LocationGroup]:
   # Have the game object update what characters are available based on the
   # currently available items and time periods.
   game.updateAvailableCharacters()

--- a/sourcefiles/logicwriter_chronosanity.py
+++ b/sourcefiles/logicwriter_chronosanity.py
@@ -268,7 +268,7 @@ def commitKeyItems(settings: rset.Settings,
     # piece of treasure. Treasure quality is based on the location's loot tier.
     for locationGroup in locationGroups:
         for location in locationGroup.getLocations():
-            if type(location) == logictypes.BaselineLocation and \
+            if isinstance(location, logictypes.BaselineLocation) and \
                (location not in chosenLocations):
 
                 # This is a baseline location without a key item.

--- a/sourcefiles/logicwriters.py
+++ b/sourcefiles/logicwriters.py
@@ -671,7 +671,7 @@ def commitKeyItems(settings: rset.Settings,
 
     for locationGroup in gameConfig.locationGroups:
         for location in locationGroup.getLocations():
-            if type(location) == logictypes.BaselineLocation and \
+            if isinstance(location, logictypes.BaselineLocation) and \
                (location not in chosenLocations):
 
                 # This is a baseline location without a key item.

--- a/sourcefiles/maps/mapmangler.py
+++ b/sourcefiles/maps/mapmangler.py
@@ -5,10 +5,7 @@ import ctenums
 import ctevent
 import ctrom
 
-import eventcommand
-import eventfunction
-
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
+from eventcommand import EventCommand as EC
 from eventfunction import EventFunction as EF
 
 import freespace

--- a/sourcefiles/mystery.py
+++ b/sourcefiles/mystery.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 import copy
 import functools
-import typing
+from typing import Any, Dict, List
 
 import random
 import randosettings as rset
 
 
-def random_weighted_choice_from_dict(choice_dict: dict[typing.Any, int]):
+def random_weighted_choice_from_dict(choice_dict: Dict[Any, int]):
     '''Make a random choice from dict keys given weights in dict values.'''
     keys, weights = zip(*choice_dict.items())
     return random.choices(keys, weights, k=1)[0]
@@ -38,9 +38,10 @@ def generate_mystery_settings(base_settings: rset.Settings) -> rset.Settings:
     # blocks off boss scaling.
     mystery_flags = list(ms.flag_prob_dict.keys())
 
-    extra_flags = [flag for flag in list(GF)
-                   if flag in base_settings.gameflags
-                   and flag not in mystery_flags]
+    extra_flags: List[rset.GameFlags] = [
+        flag for flag in GF
+        if flag in base_settings.gameflags and flag not in mystery_flags
+    ]
 
     force_disabled_flags = rset.get_forced_off(ret_settings.game_mode)
     force_enabled_flags = rset.get_forced_on(ret_settings.game_mode)

--- a/sourcefiles/objectivehints.py
+++ b/sourcefiles/objectivehints.py
@@ -3,7 +3,7 @@ Module for turning text expressions into objective choices.
 '''
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 import bossrandotypes as rotypes
 import objectivetypes

--- a/sourcefiles/objectivehints.py
+++ b/sourcefiles/objectivehints.py
@@ -3,7 +3,8 @@ Module for turning text expressions into objective choices.
 '''
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from collections import OrderedDict
+from typing import Dict, List, Tuple
 
 import bossrandotypes as rotypes
 import objectivetypes
@@ -20,6 +21,90 @@ class InvalidNameException(Exception):
 
 class WeightException(Exception):
     pass
+
+# Mapping of objective hint aliases mapped to objective hint strings
+# NOTE: this is ordered (python>=3.5) with more common random categories at the top
+_objective_hint_aliases: Dict[str, str] = {
+    'Random': '65:quest_gated, 30:boss_nogo, 15:recruit_gated',
+    'Random Gated Quest': 'quest_gated',
+    'Random Hard Quest': 'quest_late',
+    'Random Go Mode Quest': 'quest_go',
+    'Random Gated Character Recruit': 'recruit_gated',
+    'Random Boss (Includes Go Mode Dungeons)': 'boss_any',
+    'Random Boss from Go Mode Dungeon': 'boss_go',
+    'Random Boss (No Go Mode Dungeons)': 'boss_nogo',
+    'Recruit 3 Characters (Total 5)': 'recruit_3',
+    'Recruit 4 Characters (Total 6)': 'recruit_4',
+    'Recruit 5 Characters (Total 7)': 'recruit_5',
+    'Collect 10 of 20 Fragments': 'collect_fragments_10_10',
+    'Collect 10 of 30 Fragments': 'collect_fragments_10_20',
+    'Collect 3 Rocks': 'collect_rocks_3',
+    'Collect 4 Rocks': 'collect_rocks_4',
+    'Collect 5 Rocks': 'collect_rocks_5',
+    'Forge the Masamune': 'quest_forge',
+    'Charge the Moonstone': 'quest_moonstone',
+    'Trade the Jerky Away': 'quest_jerky',
+    'Defeat the Arris Dome Boss': 'quest_arris',
+    'Visit Cyrus\'s Grave with Frog': 'quest_cyrus',
+    'Defeat the Boss of Death\'s Peak': 'quest_deathpeak',
+    'Defeat the Boss of Denadoro Mountains': 'quest_denadoro',
+    'Gain Epoch Flight': 'quest_epoch',
+    'Defeat the Boss of the Factory Ruins': 'quest_factory',
+    'Defeat the Boss of the Geno Dome': 'quest_geno',
+    'Defeat the Boss of the Giant\'s Claw': 'quest_claw',
+    'Defeat the Boss of Heckran\'s Cave': 'quest_heckran',
+    'Defeat the Boss of the King\'s Trial': 'quest_shard',
+    'Defeat the Boss of Manoria Cathedral': 'quest_cathedral',
+    'Defeat the Boss of Mount Woe': 'quest_woe',
+    'Defeat the Boss of the Pendant Trial': 'quest_pendant',
+    'Defeat the Boss of the Reptite Lair': 'quest_reptite',
+    'Defeat the Boss of the Sun Palace': 'quest_sunpalace',
+    'Defeat the Boss of the Sunken Desert': 'quest_desert',
+    'Defeat the Boss in the Zeal Throneroom': 'quest_zealthrone',
+    'Defeat the Boss of Zenan Bridge': 'quest_zenan',
+    'Defeat the Black Tyrano': 'quest_blacktyrano',
+    'Defeat the Tyrano Lair Midboss': 'quest_tyranomid',
+    'Defeat the Boss in Flea\'s Spot': 'quest_flea',
+    'Defeat the Boss in Slash\'s Spot': 'quest_slash',
+    'Defeat Magus in Magus\'s Castle': 'quest_magus',
+    'Defeat the Boss in the GigaMutant Spot': 'quest_omengiga',
+    'Defeat the Boss in the TerraMutant Spot': 'quest_omenterra',
+    'Defeat the Boss in the ElderSpawn Spot': 'quest_omenelder',
+    'Defeat the Boss in the Twin Golem Spot': 'quest_twinboss',
+    'Beat Johnny in a Race': 'quest_johnny',
+    'Bet on a Fair Race and Win': 'quest_fairrace',
+    'Play the Fair Drinking Game': 'quest_soda',
+    'Defeat AtroposXR': 'boss_atropos',
+    'Defeat DaltonPlus': 'boss_dalton',
+    'Defeat DragonTank': 'boss_dragontank',
+    'Defeat ElderSpawn': 'boss_elderspawn',
+    'Defeat Flea': 'boss_flea',
+    'Defeat Flea Plus': 'boss_fleaplus',
+    'Defeat Giga Gaia': 'boss_gigagaia',
+    'Defeat GigaMutant': 'boss_gigamutant',
+    'Defeat Golem': 'boss_golem',
+    'Defeat Golem Boss': 'boss_golemboss',
+    'Defeat Guardian': 'boss_guardian',
+    'Defeat Heckran': 'boss_heckran',
+    'Defeat LavosSpawn': 'boss_lavosspawn',
+    'Defeat Magus (North Cape)': 'boss_magusnc',
+    'Defeat Masamune': 'boss_masamune',
+    'Defeat Mother Brain': 'boss_motherbrain',
+    'Defeat Mud Imp': 'boss_mudimp',
+    'Defeat Nizbel': 'boss_nizbel',
+    'Defeat Nizbel II': 'boss_nizbel2',
+    'Defeat R-Series': 'boss_rseries',
+    'Defeat Retinite': 'boss_retinite',
+    'Defeat RustTyrano': 'boss_rusttyrano',
+    'Defeat Slash': 'boss_slash',
+    'Defeat Son of Sun': 'boss_sonofsun',
+    'Defeat Super Slash': 'boss_superslash',
+    'Defeat TerraMutant': 'boss_terramutant',
+    # Skip twinboss b/c it's in quests
+    'Defeat Yakra': 'boss_yakra',
+    'Defeat Yakra XIII': 'boss_yakraxiii',
+    'Defeat Zombor': 'boss_zombor'
+}
 
 
 def get_forced_bosses(hint: str) -> list[rotypes.BossID]:
@@ -45,6 +130,26 @@ def get_forced_bosses(hint: str) -> list[rotypes.BossID]:
             continue
 
     return boss_list
+
+
+def get_objective_hint_aliases() -> OrderedDict[str, str]:
+    '''Ordered objective hint aliases mapped to objective strings.'''
+    # dicts maintain definition order in python>=3.5 but coerce to ordered
+    # for consistency with django web app, and also as means to make a copy
+    # instead of passing _objective_hint_aliases as reference
+    return OrderedDict(_objective_hint_aliases.items())
+
+
+def normalize_objectives_from_hints(hints: List[str]) -> List[str]:
+    '''Normalize all hints into objectives strings.
+
+    This converts hints specified with a simple objective preset string into
+    a parseable objective string. The simple objective presets are an option
+    for specifiying objectives in the CLI, TK GUI and web GUI, as an alternative
+    to using the native objective hint string format.
+    '''
+    return [_objective_hint_aliases.get(hint, hint) for hint in hints]
+
 
 def parse_boss_name(name: str):
     '''
@@ -332,13 +437,14 @@ def is_hint_valid(hint: str) -> Tuple[bool, str]:
     if hint == '':
         return True, ''
 
-    fake_settings = rset.Settings.get_race_presets()
+    fake_settings = rset.Settings()
     boss_assign_dict = rotypes.get_default_boss_assignment()
     char_assign_dict = pcrecruit.get_base_recruit_dict()
 
+    normalized_hint = normalize_objectives_from_hints([hint])[0]
+
     try:
-        dist = parse_hint(hint, fake_settings, boss_assign_dict,
-                          char_assign_dict)
+        dist = parse_hint(normalized_hint, fake_settings, boss_assign_dict, char_assign_dict)
     except InvalidNameException as exc:
         return (False, str(exc))
 

--- a/sourcefiles/presetimizer.py
+++ b/sourcefiles/presetimizer.py
@@ -102,16 +102,20 @@ def build_preset(args: argparse.Namespace) -> Dict[str, rset.JSONType]:
     ret: Dict[str, Any] = {'settings': settings}
 
     if args.metadata:
-        metadata.update(json.loads(args.metadata))
+        metadata.update(args.metadata)
     ret['metadata'] = metadata
 
     return ret
 
 
-if __name__ == '__main__':
+def main():
     parser = get_parser()
     args = parser.parse_args()
     preset = build_preset(args)
 
     # write to stdout
     print(json.dumps(preset, cls=jotjson.JOTJSONEncoder, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/sourcefiles/presetimizer.py
+++ b/sourcefiles/presetimizer.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+'''
+Presetimizer: script for convenient creation/validation of .preset.json files.
+
+This script is a tool for building preset files without requiring a CT rom or needing to generate
+a seed (like randomizer.py requires). It supports (almost) all of the arguments from randomizer.py which affect
+generation of a seed and can go into a preset file. Cosmetic options, which can be set "post-generation"
+in the web GUI, are not included in a preset file.
+
+Presets can also be built from other presets (using the '--input-preset' argument), with additional
+arguments passed in (similar to using '--preset' in randomizer.py).
+
+Metadata can be passed in as a string in JSON format via the '--metadata' argument.
+
+This script outputs the generated preset directly to stdout. Without errors, it does not output anything else to
+stdout, so it's output can be re-directed to a file to create a .preset.json file.
+'''
+from __future__ import annotations
+import argparse
+import json
+import types
+
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Type
+
+import arguments
+import jotjson
+import randosettings as rset
+
+
+class PresetimizerOptionsAG(arguments.ArgumentGroup):
+    _title = 'Presetimizer Options'
+
+    @classmethod
+    def arguments(cls) -> Generator[arguments.Argument, None, None]:
+        yield arguments.Argument(
+            '--metadata', help='metadata to add to preset (JSON) [{}]', default='{}', type=json.loads
+        )
+        yield arguments.Argument(
+            '--input-preset',
+            '-i',
+            help='path to preset JSON file from which to load settings',
+            default=None,
+            type=Path,
+        )
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(formatter_class=arguments.SmartFormatter)
+    groups: List[Type[arguments.ArgumentGroup]] = [PresetimizerOptionsAG]
+    groups.extend(arguments.ALL_GENERATION_AG)
+    for ag in groups:
+        ag.add_to_parser(parser)
+    return parser
+
+
+def build_preset(args: argparse.Namespace) -> Dict[str, rset.JSONType]:
+    '''Build preset based on args.'''
+
+    presettings = {}
+    metadata: Dict[str, rset.JSONType] = {}
+    if args.input_preset:
+        data = json.loads(args.input_preset.read_text())
+        presettings = data['settings']
+        metadata = data.get('metadata', {})
+
+        # add preset into arguments to let usual preset handling take place
+        preset = arguments.GenerationOptionsAG.load_preset(args.input_preset)
+        setattr(args, 'preset', preset)
+
+    # override to_jot_json to minimize output for presets
+    def _to_jot_json(self: rset.Settings) -> Dict[str, Any]:
+        jot: Dict[str, Any] = {
+            'game_mode': str(self.game_mode),
+            'enemy_difficulty': str(self.enemy_difficulty),
+            'item_difficulty': str(self.item_difficulty),
+            'techorder': str(self.techorder),
+            'shopprices': str(self.shopprices),
+        }
+
+        # only add gameflags when there are some
+        if self.gameflags:
+            jot['gameflags'] = self.gameflags
+
+        # only include these self when args related were explicitly passed or from inherited preset
+        # NOTE: no ro_setitngs as no means of setting with CLI/presetimizer at this time
+        if 'mystery_settings' in presettings or 'mystery' in vars(args):
+            jot['mystery_settings'] = self.mystery_settings
+        if 'bucket_settings' in presettings or 'bucket_list' in vars(args):
+            jot['bucket_settings'] = self.bucket_settings
+        if 'char_settings' in presettings or any(
+            f"{name.lower()}_choices" in vars(args) for name in rset.CharNames.default()
+        ):
+            jot['char_settings'] = {'choices': self.char_settings.choices}
+        if 'tab_settings' in presettings or any(arg.arg in args for arg in arguments.TabSettingsAG.arguments()):
+            jot['tab_settings'] = self.tab_settings
+        return jot
+
+    settings = arguments.args_to_settings(args)
+    setattr(settings, 'to_jot_json', types.MethodType(_to_jot_json, settings))
+
+    ret: Dict[str, Any] = {'settings': settings}
+
+    if args.metadata:
+        metadata.update(json.loads(args.metadata))
+    ret['metadata'] = metadata
+
+    return ret
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    preset = build_preset(args)
+
+    # write to stdout
+    print(json.dumps(preset, cls=jotjson.JOTJSONEncoder, indent=2))

--- a/sourcefiles/presets/catalack-cup-top8.preset.json
+++ b/sourcefiles/presets/catalack-cup-top8.preset.json
@@ -1,0 +1,23 @@
+{
+  "metadata": {
+    "name": "Catalack Cup Top8",
+    "desc": "Settings for Catalack Cup tournament Top 8 seeds."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Hard",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.BOSS_RANDO",
+      "GameFlags.FAST_TABS",
+      "GameFlags.HEALING_ITEM_RANDO",
+      "GameFlags.GEAR_RANDO",
+      "GameFlags.BOSS_SPOT_HP"
+    ]
+  }
+}

--- a/sourcefiles/presets/catalack-cup.preset.json
+++ b/sourcefiles/presets/catalack-cup.preset.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "name": "Catalack Cup",
+    "desc": "Settings for Catalack Cup tournament seeds."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Normal",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.BOSS_RANDO",
+      "GameFlags.FAST_TABS",
+      "GameFlags.HEALING_ITEM_RANDO",
+      "GameFlags.FREE_MENU_GLITCH",
+      "GameFlags.GEAR_RANDO",
+      "GameFlags.BOSS_SPOT_HP"
+    ]
+  }
+}

--- a/sourcefiles/presets/hard.preset.json
+++ b/sourcefiles/presets/hard.preset.json
@@ -1,0 +1,19 @@
+{
+  "metadata": {
+    "name": "Hard",
+    "desc": "Standard hard preset with added difficulty and locked chars."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Hard",
+    "item_difficulty": "Hard",
+    "techorder": "Balanced random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.BOSS_SCALE",
+      "GameFlags.LOCKED_CHARS",
+      "GameFlags.FAST_TABS"
+    ]
+  }
+}

--- a/sourcefiles/presets/legacy-of-cyrus.preset.json
+++ b/sourcefiles/presets/legacy-of-cyrus.preset.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "name": "Legacy of Cyrus",
+    "desc": "Legacy of Cyrus preset with gear rando."
+  },
+  "settings": {
+    "game_mode": "Legacy of cyrus",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Normal",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.UNLOCKED_MAGIC",
+      "GameFlags.FAST_TABS",
+      "GameFlags.GEAR_RANDO"
+    ]
+  }
+}

--- a/sourcefiles/presets/lost-worlds.preset.json
+++ b/sourcefiles/presets/lost-worlds.preset.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "name": "Lost Worlds",
+    "desc": "Lost Worlds preset."
+  },
+  "settings": {
+    "game_mode": "Lost worlds",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Normal",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_TABS"
+    ]
+  }
+}

--- a/sourcefiles/presets/millennial-prix.preset.json
+++ b/sourcefiles/presets/millennial-prix.preset.json
@@ -1,0 +1,21 @@
+{
+  "metadata": {
+    "name": "Millennial Prix",
+    "desc": "Settings for Millennial Prix tournament seeds."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Normal",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.BOSS_RANDO",
+      "GameFlags.FAST_TABS",
+      "GameFlags.BOSS_SPOT_HP"
+    ]
+  }
+}

--- a/sourcefiles/presets/new-player.preset.json
+++ b/sourcefiles/presets/new-player.preset.json
@@ -1,0 +1,21 @@
+{
+  "metadata": {
+    "name": "New Player",
+    "desc": "Slightly easier preset intended for newer players of Jets of Time."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Easy",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.UNLOCKED_MAGIC",
+      "GameFlags.VISIBLE_HEALTH",
+      "GameFlags.FAST_TABS"
+    ]
+  }
+}

--- a/sourcefiles/presets/race.preset.json
+++ b/sourcefiles/presets/race.preset.json
@@ -1,0 +1,19 @@
+{
+  "metadata": {
+    "name": "Race",
+    "desc": "Standard racing preset."
+  },
+  "settings": {
+    "game_mode": "Standard",
+    "enemy_difficulty": "Normal",
+    "item_difficulty": "Normal",
+    "techorder": "Full random",
+    "shopprices": "Normal",
+    "gameflags": [
+      "GameFlags.FIX_GLITCH",
+      "GameFlags.ZEAL_END",
+      "GameFlags.FAST_PENDANT",
+      "GameFlags.FAST_TABS"
+    ]
+  }
+}

--- a/sourcefiles/randoconfig.py
+++ b/sourcefiles/randoconfig.py
@@ -4,7 +4,6 @@
 # GameConfig out to the rom.
 from __future__ import annotations
 import dataclasses
-import typing
 from typing import Optional, Union
 
 from treasures import treasuretypes
@@ -23,8 +22,6 @@ import ctenums
 import ctrom
 import ctstrings
 import techdb
-
-import randosettings as rset
 
 
 @dataclasses.dataclass

--- a/sourcefiles/randoconfig.py
+++ b/sourcefiles/randoconfig.py
@@ -184,16 +184,16 @@ class RandoConfig:
             objectives = []
         self.objectives = objectives
 
-    def _jot_json(self):
+    def to_jot_json(self):
         def enum_key_dict(d):
             "Properly uses str(key) for dicts with StrIntEnum keys."
             return { str(k): v for (k,v) in d.items() }
 
         def merged_list_dict(l):
-            """For things that are a list of objects, each having a _jot_json
+            """For things that are a list of objects, each having a to_jot_json
             method that returns a single-key dict, this merges those dicts into
             one."""
-            return {k: v for d in l for k, v in d._jot_json().items()}
+            return {k: v for d in l for k, v in d.to_jot_json().items()}
 
         def enum_enum_dict(d):
             "For dicts with both keys and values that are StrIntEnums"
@@ -221,7 +221,7 @@ class RandoConfig:
         boss_details_dict[str(BossID.BLACK_TYRANO)]['element'] = \
             str(bossrando.get_black_tyrano_element(self))
 
-        chars = self.pcstats._jot_json()
+        chars = self.pcstats.to_jot_json()
         # the below is ugly, would be nice to have tech lists on PlayerChar
         # objects maybe
         def get_tech_list(char_id: int, tech_db: techdb.TechDB):

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -1279,9 +1279,8 @@ class Randomizer:
                 self.write_json_spoiler_log(real_outfile)
         else:
             json.dump(
-                {"configuration": self.config,
-                 "settings": self.settings},
-                outfile, cls=JOTJSONEncoder
+                {"configuration": self.config, "settings": self.settings},
+                outfile, cls=JOTJSONEncoder, indent=2
             )
 
     def _summarize_dupes(self):

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -2267,7 +2267,7 @@ def main():
     parser = arguments.get_parser()
     args = parser.parse_args()
 
-    if not args.input_file.exists():
+    if not args.input_file or not args.input_file.exists():
         raise FileNotFoundError("Invalid input file path.")
 
     if args.output_path is None:

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -1298,8 +1298,8 @@ class Randomizer:
                     ", ".join([str(CharID(i))
                                for i in (set(range(7)) - set(choicelist))])
 
-        chars = {c: summarize_single(self.settings.char_choices[c])
-                 for c in range(len(self.settings.char_choices))}
+        chars = {c: summarize_single(self.settings.char_settings.choices[c])
+                 for c in range(len(self.settings.char_settings.choices))}
         rv = ""
         for c in sorted(chars.keys()):
             if chars[c] != "Any":
@@ -1334,7 +1334,7 @@ class Randomizer:
                 f"Speed {tab_set.speed_min}-{tab_set.speed_max}\n"
             )
         if rset.GameFlags.CHAR_RANDO in gf and \
-           self.settings.char_choices != rset.Settings().char_choices:
+           self.settings.char_settings.choices != rset.Settings().char_settings.choices:
 
             dupes = self._summarize_dupes()
             file_object.write(f"Characters: {dupes}\n")
@@ -1925,7 +1925,7 @@ class Randomizer:
             cosmetichacks.death_peak_singing_mountain_music(ctrom, settings)
 
         cosmetichacks.set_pc_names(
-            ctrom, *settings.char_names
+            ctrom, *settings.char_settings.names
         )
 
         if rset.CosmeticFlags.REDUCE_FLASH in cos_flags:

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -3,7 +3,6 @@ The Chrono Trigger: Jets of Time Randomizer
 '''
 from __future__ import annotations
 
-import copy
 import os
 import random
 import pickle

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -76,7 +76,7 @@ class CreateToolTip(object):
         self.tw.wm_overrideredirect(True)
         self.tw.wm_geometry("+%d+%d" % (x, y))
         displaytext = self.text
-        if type(self.text) == tk.StringVar:
+        if isinstance(self.text, tk.StringVar):
             displaytext = self.text.get()
         label = tk.Label(self.tw, text=displaytext, justify='left',
                          background="#ffffff", relief='solid', borderwidth=1,

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -19,7 +19,7 @@ import randomizer
 import bossrandotypes as rotypes
 from randosettings import Settings, GameFlags, Difficulty, ShopPrices, \
     TechOrder, TabSettings, TabRandoScheme, ROSettings, ROFlags, \
-    CosmeticFlags, GameMode, MysterySettings, CharSettings
+    CosmeticFlags, GameMode, MysterySettings, CharNames
 from ctenums import ActionMap, InputMap
 import ctoptions
 import ctrom
@@ -279,7 +279,7 @@ class RandoGUI:
 
     def set_settings(self, new_settings: Settings):
         self.__settings = new_settings
-        # print(self.__settings.char_choices)
+        # print(self.__settings.char_settings.choices)
         # print(self.__settings.gameflags)
         # print(self.__settings.get_flag_string())
         self.update_gui_vars()
@@ -400,14 +400,8 @@ class RandoGUI:
             value = InputMap[button.get().upper().replace(' ', '_')]
             self.settings.ctoptions.controller_binds.mappings[action] = value
 
-        self.settings.char_names[0] = self.char_names['Crono'].get()
-        self.settings.char_names[1] = self.char_names['Marle'].get()
-        self.settings.char_names[2] = self.char_names['Lucca'].get()
-        self.settings.char_names[3] = self.char_names['Robo'].get()
-        self.settings.char_names[4] = self.char_names['Frog'].get()
-        self.settings.char_names[5] = self.char_names['Ayla'].get()
-        self.settings.char_names[6] = self.char_names['Magus'].get()
-        self.settings.char_names[7] = self.char_names['Epoch'].get()
+        for name in CharNames.default():
+            self.settings.char_settings.names[name] = self.char_names[name].get()
 
         self.settings.gameflags = \
             reduce(lambda a, b: a | b, flags, GameFlags(False))
@@ -432,10 +426,10 @@ class RandoGUI:
 
         # RC (dup duals already taken, just char choices)
         for i in range(7):
-            self.settings.char_choices[i] = []
+            self.settings.char_settings.choices[i] = []
             for j in range(7):
                 if self.char_choices[i][j].get() == 1:
-                    self.settings.char_choices[i].append(j)
+                    self.settings.char_settings.choices[i].append(j)
 
         # RO Settings
         # print(self.bosses)
@@ -507,14 +501,8 @@ class RandoGUI:
                 self.cosmetic_flag_dict[x].set(0)
 
         # Char names
-        self.char_names['Crono'].set(self.settings.char_names[0])
-        self.char_names['Marle'].set(self.settings.char_names[1])
-        self.char_names['Lucca'].set(self.settings.char_names[2])
-        self.char_names['Robo'].set(self.settings.char_names[3])
-        self.char_names['Frog'].set(self.settings.char_names[4])
-        self.char_names['Ayla'].set(self.settings.char_names[5])
-        self.char_names['Magus'].set(self.settings.char_names[6])
-        self.char_names['Epoch'].set(self.settings.char_names[7])
+        for name in CharNames.default():
+            self.char_names[name].set(self.settings.char_settings.names[name])
 
         increment_vars = [
             'menu_background',
@@ -567,7 +555,7 @@ class RandoGUI:
         # RC char choices
         for i in range(7):
             for j in range(7):
-                if j in self.settings.char_choices[i]:
+                if j in self.settings.char_settings.choices[i]:
                     self.char_choices[i][j].set(1)
                 else:
                     self.char_choices[i][j].set(0)
@@ -826,7 +814,7 @@ class RandoGUI:
         row = 0
         col = 0
 
-        char_names = CharSettings.default_names()[:-1]
+        char_names = CharNames.default()[:-1]
 
         row += 1
 
@@ -1727,8 +1715,8 @@ class RandoGUI:
                 if self.output_dir is None or self.output_dir.get() == '':
                     self.output_dir.set(str(input_path.parent))
 
-                base_name = input_path.name.split('.')[0]
-                out_dir = self.output_dir.get()
+                base_name = pathlib.Path(input_path.name.split('.')[0])
+                out_dir = pathlib.Path(self.output_dir.get())
 
                 writer = randomizer.RandomizerWriter(rando, base_name=base_name)
                 writer.write_output_rom(out_dir)

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -11,6 +11,7 @@ from tkinter import ttk
 from tkinter.filedialog import askopenfilename
 from tkinter.filedialog import askdirectory
 from tkinter import messagebox
+from typing import Optional
 
 # custom/local libraries
 import bucketgui
@@ -2766,7 +2767,7 @@ class RandoGUI:
             #update listbox in another frame
             parent.listbox_values.set(options)
             
-        def _construct_callback(action: ActionMap = None):
+        def _construct_callback(action: Optional[ActionMap] = None):
             '''
             Constructs callback function for gui usage.
             '''

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -1415,7 +1415,7 @@ class RandoGUI:
         for action, button in self.controller_binds.items():
             try:
                 value = InputMap[button.get().upper().replace(' ', '_')]
-            except:
+            except Exception:
                 messagebox.showerror(
                     'Options Controller Error',
                     'All button binds must be set.'
@@ -2710,25 +2710,12 @@ class RandoGUI:
             and assignment dropdowns.
             '''
 
-            # Initially populate the list.
-            ret = [str(x) for x in InputMap]
-
             # Get the assigned buttons.
             assigned = [
                 y.get() for x, y in binds.items() if y.get() != 'Unset'
             ]
 
-            for x in InputMap:
-                # Force strings to enable comparisons;
-                # StringVars only output str, not StrIntEnum
-                x = str(x)
-                try:
-                    if x in assigned:
-                        ret.remove(x)
-                except:  # TODO: Figure out what exceptions are raised.
-                    pass
-
-            return ret
+            return [str(x) for x in InputMap if str(x) not in assigned]
 
         def _update_display_pg(pg_strs):
             '''

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -3016,4 +3016,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -18,7 +18,7 @@ import randomizer
 import bossrandotypes as rotypes
 from randosettings import Settings, GameFlags, Difficulty, ShopPrices, \
     TechOrder, TabSettings, TabRandoScheme, ROSettings, ROFlags, \
-    CosmeticFlags, GameMode, MysterySettings
+    CosmeticFlags, GameMode, MysterySettings, CharSettings
 from ctenums import ActionMap, InputMap
 import ctoptions
 import ctrom
@@ -825,9 +825,7 @@ class RandoGUI:
         row = 0
         col = 0
 
-        char_names = [
-            'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus'
-        ]
+        char_names = CharSettings.default_names()[:-1]
 
         row += 1
 

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 import pickle
 import random
-import sys
 import threading
 import tkinter as tk
 from tkinter import ttk
@@ -19,13 +18,12 @@ import randomizer
 import bossrandotypes as rotypes
 from randosettings import Settings, GameFlags, Difficulty, ShopPrices, \
     TechOrder, TabSettings, TabRandoScheme, ROSettings, ROFlags, \
-    CosmeticFlags, BucketSettings, GameMode, MysterySettings
-from ctenums import LocID, ActionMap, InputMap
+    CosmeticFlags, GameMode, MysterySettings
+from ctenums import ActionMap, InputMap
 import ctoptions
 import ctrom
 import ctstrings
 
-import objectivehints as oh
 
 #
 # tkinter does not have a native tooltip implementation.

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -19,6 +19,10 @@ class StrIntEnum(IntEnum):
         return x
 
     @classmethod
+    def default(cls):
+        raise NotImplementedError(f"No .default implemented for {cls}")
+
+    @classmethod
     def str_dict(cls: Type[SIE]) -> dict[SIE, str]:
         enum_list: list[SIE] = list(cls)
         return dict((x, str(x)) for x in enum_list)
@@ -38,17 +42,29 @@ class GameMode(StrIntEnum):
     LEGACY_OF_CYRUS = auto()
     VANILLA_RANDO = auto()
 
+    @classmethod
+    def default(_):
+        return GameMode.STANDARD
+
 
 class Difficulty(StrIntEnum):
     EASY = 0
     NORMAL = 1
     HARD = 2
 
+    @classmethod
+    def default(_):
+        return Difficulty.NORMAL
+
 
 class TechOrder(StrIntEnum):
     NORMAL = 0
     FULL_RANDOM = 1
     BALANCED_RANDOM = 2
+
+    @classmethod
+    def default(_):
+        return TechOrder.FULL_RANDOM
 
 
 class ShopPrices(StrIntEnum):
@@ -57,8 +73,18 @@ class ShopPrices(StrIntEnum):
     FULLY_RANDOM = 2
     FREE = 3
 
+    @classmethod
+    def default(_):
+        return ShopPrices.NORMAL
+
 
 class SerializableFlag(Flag):
+    def __add__(self, other: Flag):
+        return self | other
+
+    def __sub__(self, other: Flag):
+        return self & ~other
+
     def to_jot_json(self) -> List[str]:
         return [str(flag) for flag in type(self) if flag in self]
 
@@ -105,12 +131,6 @@ class GameFlags(SerializableFlag):
     REMOVE_BLACK_OMEN_SPOT = auto()
     # No longer Logic Tweak Flags
     TECH_DAMAGE_RANDO = auto()
-
-    def __add__(self, other: GameFlags):
-        return self | other
-
-    def __sub__(self, other: GameFlags):
-        return self & ~other
 
 
 # Dictionary for what flags force what other flags off.
@@ -217,10 +237,14 @@ class TabRandoScheme(StrIntEnum):
     UNIFORM = 0
     BINOMIAL = 1
 
+    @classmethod
+    def default(_):
+        return TabRandoScheme.UNIFORM
+
 
 @dataclass
 class TabSettings:
-    scheme: TabRandoScheme = TabRandoScheme.UNIFORM
+    scheme: TabRandoScheme = TabRandoScheme.default()
     binom_success: float = 0.5  # Only used by binom if set
     power_min: int = 2
     power_max: int = 4
@@ -388,12 +412,12 @@ class Settings:
 
     def __init__(self):
 
-        self.game_mode = GameMode.STANDARD
-        self.item_difficulty = Difficulty.NORMAL
-        self.enemy_difficulty = Difficulty.NORMAL
+        self.game_mode = GameMode.default()
+        self.item_difficulty = Difficulty.default()
+        self.enemy_difficulty = Difficulty.default()
 
-        self.techorder = TechOrder.FULL_RANDOM
-        self.shopprices = ShopPrices.NORMAL
+        self.techorder = TechOrder.default()
+        self.shopprices = ShopPrices.default()
 
         self.mystery_settings = MysterySettings()
 

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -454,7 +454,12 @@ class CharChoices(UserList):
         return [index for index in range(7) if index in indices]
 
     def to_jot_json(self) -> List[List[int]]:
-        return [[choice for choice in character] for character in self.data]
+        def _choices(choices):
+            if isinstance(choices, str):
+                return choices
+            else:
+                return [choice for choice in choices]
+        return [_choices(character) for character in self.data]
 
 
 class CharNames(UserList):

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -229,8 +229,13 @@ class TabSettings:
     speed_min: int = 1
     speed_max: int = 1
 
+    def to_jot_json(self) -> Dict[str, JSONPrimitive]:
+        data = {field.name: getattr(self, field.name) for field in fields(self)}
+        data['scheme'] = str(self.scheme)
+        return data
 
-class ROFlags(Flag):
+
+class ROFlags(SerializableFlag):
     '''
     Flags which can be passed to boss rando.
     '''
@@ -287,6 +292,13 @@ class ROSettings:
 
         return ROSettings(spots, boss_list, ro_flags)
 
+    def to_jot_json(self) -> Dict[str, Any]:
+        data = {}
+        for item in fields(self):
+            attr = getattr(self, item.name)
+            data[item.name] = [str(x) for x in attr] if isinstance(attr, List) else attr
+        return data
+
 
 @dataclass
 class BucketSettings:
@@ -300,6 +312,9 @@ class BucketSettings:
     num_objectives: int = 5
     num_objectives_needed: int = 4
     hints: list[str] = field(default_factory=list)
+
+    def to_jot_json(self) -> Dict[str, JSONType]:
+        return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
 class MysterySettings:
@@ -346,6 +361,17 @@ class MysterySettings:
             GameFlags.HEALING_ITEM_RANDO: 0.25
         }
 
+    def to_jot_json(self) -> Dict[str, JSONType]:
+        attrs = [
+            'game_mode_freqs',
+            'item_difficulty_freqs',
+            'enemy_difficulty_freqs',
+            'tech_order_freqs',
+            'shop_price_freqs',
+            'flag_prob_dict',
+        ]
+        return {attr: {str(k): f for k, f in getattr(self, attr).items()} for attr in attrs}
+
     def __str__(self):
         ret_str = ''
         ret_str += str(self.game_mode_freqs) + '\n'
@@ -390,17 +416,24 @@ class Settings:
             'Epoch'
         ]
 
-    def to_jot_json(self):
+    def to_jot_json(self) -> Dict[str, Any]:
         return {
-            "seed": self.seed,
-            "mode": str(self.game_mode),
+            "game_mode": str(self.game_mode),
             "enemy_difficulty": str(self.enemy_difficulty),
             "item_difficulty": str(self.item_difficulty),
-            "tech_order": str(self.techorder),
-            "shops": str(self.shopprices),
-            "flags": self.gameflags,
+            "techorder": str(self.techorder),
+            "shopprices": str(self.shopprices),
+            "mystery_settings": self.mystery_settings,
+            "gameflags": self.gameflags,
             "initial_flags": self.initial_flags,
-            "cosmetic_flags": self.cosmetic_flags
+            "char_choices": self.char_choices,
+            "ro_settings": self.ro_settings,
+            "bucket_settings": self.bucket_settings,
+            "tab_settings": self.tab_settings,
+            "cosmetic_flags": self.cosmetic_flags,
+            "ctoptions": self.ctoptions,
+            "seed": self.seed,
+            "char_names": self.char_names,
         }
 
     @staticmethod

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -353,36 +353,46 @@ class CharSettings:
         return ['Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch']
 
 
+@dataclass
 class MysterySettings:
+    '''Settings related to generating mystery seeds.'''
+
+    game_mode_freqs: Dict[GameMode, int] = field(default_factory=dict)
+    item_difficulty_freqs: Dict[Difficulty, int] = field(default_factory=dict)
+    enemy_difficulty_freqs: Dict[Difficulty, int] = field(default_factory=dict)
+    tech_order_freqs: Dict[TechOrder, int] = field(default_factory=dict)
+    shop_price_freqs: Dict[ShopPrices, int] = field(default_factory=dict)
+    flag_prob_dict: Dict[GameFlags, float] = field(default_factory=dict)
+
     def __init__(self):
-        self.game_mode_freqs: dict[GameMode, int] = {
+        self.game_mode_freqs = {
             GameMode.STANDARD: 75,
             GameMode.LOST_WORLDS: 25,
             GameMode.LEGACY_OF_CYRUS: 0,
             GameMode.ICE_AGE: 0,
             GameMode.VANILLA_RANDO: 0
         }
-        self.item_difficulty_freqs: dict[Difficulty, int] = {
+        self.item_difficulty_freqs = {
             Difficulty.EASY: 15,
             Difficulty.NORMAL: 70,
             Difficulty.HARD: 15
         }
-        self.enemy_difficulty_freqs: dict[Difficulty, int] = {
+        self.enemy_difficulty_freqs = {
             Difficulty.NORMAL: 75,
             Difficulty.HARD: 25
         }
-        self.tech_order_freqs: dict[TechOrder, int] = {
+        self.tech_order_freqs = {
             TechOrder.NORMAL: 10,
             TechOrder.BALANCED_RANDOM: 10,
             TechOrder.FULL_RANDOM: 80
         }
-        self.shop_price_freqs: dict[ShopPrices, int] = {
+        self.shop_price_freqs = {
             ShopPrices.NORMAL: 70,
             ShopPrices.MOSTLY_RANDOM: 10,
             ShopPrices.FULLY_RANDOM: 10,
             ShopPrices.FREE: 10
         }
-        self.flag_prob_dict: dict[GameFlags, float] = {
+        self.flag_prob_dict = {
             GameFlags.TAB_TREASURES: 0.10,
             GameFlags.UNLOCKED_MAGIC: 0.5,
             GameFlags.BUCKET_LIST: 0.15,
@@ -398,26 +408,21 @@ class MysterySettings:
         }
 
     def to_jot_json(self) -> Dict[str, JSONType]:
-        attrs = [
-            'game_mode_freqs',
-            'item_difficulty_freqs',
-            'enemy_difficulty_freqs',
-            'tech_order_freqs',
-            'shop_price_freqs',
-            'flag_prob_dict',
-        ]
-        return {attr: {str(k): f for k, f in getattr(self, attr).items()} for attr in attrs}
+        return {
+            field.name: {str(k): freq for k, freq in self[field.name].items()}
+            for field in fields(self)
+        }
 
-    def __str__(self):
-        ret_str = ''
-        ret_str += str(self.game_mode_freqs) + '\n'
-        ret_str += str(self.item_difficulty_freqs) + '\n'
-        ret_str += str(self.enemy_difficulty_freqs) + '\n'
-        ret_str += str(self.tech_order_freqs) + '\n'
-        ret_str += str(self.shop_price_freqs) + '\n'
-        ret_str += str(self.flag_prob_dict) + '\n'
+    def update(self, **items) -> MysterySettings:
+        for attr, updates in items.items():
+            self[attr].update(updates)
+        return self
 
-        return ret_str
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __str__(self) -> str:
+        return '\n'.join(str(self[field.name]) for field in fields(self)) + '\n'
 
 
 class Settings:

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -341,6 +341,18 @@ class BucketSettings:
         return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
+class CharSettings:
+    '''Contains settings related to characters.'''
+
+    def __init__(self):
+        self.names: List[str] = self.default_names()
+
+    @staticmethod
+    def default_names() -> List[str]:
+        '''Default character names.'''
+        return ['Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch']
+
+
 class MysterySettings:
     def __init__(self):
         self.game_mode_freqs: dict[GameMode, int] = {
@@ -435,10 +447,7 @@ class Settings:
 
         self.seed = ''
 
-        self.char_names: list[str] = [
-            'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus',
-            'Epoch'
-        ]
+        self.char_names = CharSettings.default_names()
 
     def to_jot_json(self) -> Dict[str, Any]:
         return {

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -56,7 +56,12 @@ class ShopPrices(StrIntEnum):
     FREE = 3
 
 
-class GameFlags(Flag):
+class SerializableFlag(Flag):
+    def to_jot_json(self) -> List[str]:
+        return [str(flag) for flag in type(self) if flag in self]
+
+
+class GameFlags(SerializableFlag):
     FIX_GLITCH = auto()
     BOSS_SCALE = auto()
     ZEAL_END = auto()
@@ -198,7 +203,7 @@ def get_forced_on(flag: GameFlags) -> GameFlags:
     return _forced_on_dict.get(flag, GameFlags(0))
 
 
-class CosmeticFlags(Flag):
+class CosmeticFlags(SerializableFlag):
     ZENAN_ALT_MUSIC = auto()
     DEATH_PEAK_ALT_MUSIC = auto()
     QUIET_MODE = auto()
@@ -383,7 +388,7 @@ class Settings:
             'Epoch'
         ]
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
             "seed": self.seed,
             "mode": str(self.game_mode),

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import json
 from collections import UserList
 from enum import Flag, IntEnum, auto
 from dataclasses import dataclass, field, fields
@@ -707,6 +708,21 @@ class Settings:
             'ctoptions': self.ctoptions,
             'seed': self.seed,
         }
+
+    @staticmethod
+    def from_preset_file(preset: Path) -> Settings:
+        if not preset.exists():
+            raise FileNotFoundError(f"Preset file does not exist: {preset}")
+
+        # late import to prevent circular import between jotjson and randosettings
+        from jotjson import JOTJSONDecoder
+
+        try:
+            data = json.loads(preset.read_text(), cls=JOTJSONDecoder)
+        except Exception as ex:
+            raise ValueError(f"Failed to parse preset as JSON: {preset}") from ex
+
+        return data['settings']
 
     @staticmethod
     def get_race_presets():

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -3,6 +3,7 @@ import json
 from collections import UserList
 from enum import Flag, IntEnum, auto
 from dataclasses import dataclass, field, fields
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Union, Mapping, Optional, Sequence, Tuple, Type, TypeVar
 
 import bossrandotypes as rotypes
@@ -12,6 +13,7 @@ JSONPrimitive = Optional[Union[int, float, bool, str]]
 JSONType = Union[JSONPrimitive, Mapping[str, "JSONType"], Sequence["JSONType"]]
 SIE = TypeVar('SIE', bound='StrIntEnum')
 
+PRESETS_PATH: Path = Path(__file__).parent / 'presets'
 
 class StrIntEnum(IntEnum):
 
@@ -725,108 +727,29 @@ class Settings:
         return data['settings']
 
     @staticmethod
-    def get_race_presets():
-        ret = Settings()
-
-        ret.item_difficulty = Difficulty.NORMAL
-        ret.enemy_difficulty = Difficulty.NORMAL
-
-        ret.shopprices = ShopPrices.NORMAL
-        ret.techorder = TechOrder.FULL_RANDOM
-
-        ret.gameflags = (GameFlags.FIX_GLITCH |
-                         GameFlags.FAST_PENDANT |
-                         GameFlags.ZEAL_END)
-
-        ret.seed = ''
-
-        return ret
+    def get_race_presets() -> Settings:
+        return Settings.from_preset_file(PRESETS_PATH / 'race.preset.json')
 
     @staticmethod
-    def get_new_player_presets():
-        ret = Settings()
-
-        ret.item_difficulty = Difficulty.EASY
-        ret.enemy_difficulty = Difficulty.NORMAL
-
-        ret.shopprices = ShopPrices.NORMAL
-        ret.techorder = TechOrder.FULL_RANDOM
-
-        ret.gameflags = (GameFlags.FIX_GLITCH |
-                         GameFlags.FAST_PENDANT |
-                         GameFlags.ZEAL_END |
-                         GameFlags.UNLOCKED_MAGIC |
-                         GameFlags.VISIBLE_HEALTH |
-                         GameFlags.FAST_TABS)
-
-        ret.seed = ''
-
-        return ret
+    def get_new_player_presets() -> Settings:
+        return Settings.from_preset_file(PRESETS_PATH / 'new-players.preset.json')
 
     @staticmethod
-    def get_lost_worlds_presets():
-        ret = Settings()
-
-        ret.game_mode = GameMode.LOST_WORLDS
-        ret.item_difficulty = Difficulty.NORMAL
-        ret.enemy_difficulty = Difficulty.NORMAL
-
-        ret.shopprices = ShopPrices.NORMAL
-        ret.techorder = TechOrder.FULL_RANDOM
-
-        ret.gameflags = (GameFlags.FIX_GLITCH | GameFlags.ZEAL_END)
-
-        ret.seed = ''
-
-        return ret
+    def get_lost_worlds_presets() -> Settings:
+        return Settings.from_preset_file(PRESETS_PATH / 'lost-worlds.preset.json')
 
     @staticmethod
-    def get_hard_presets():
-        ret = Settings()
-
-        ret.item_difficulty = Difficulty.HARD
-        ret.enemy_difficulty = Difficulty.HARD
-
-        ret.shopprices = ShopPrices.NORMAL
-        ret.techorder = TechOrder.BALANCED_RANDOM
-
-        ret.gameflags = (GameFlags.FIX_GLITCH |
-                         GameFlags.BOSS_SCALE |
-                         GameFlags.LOCKED_CHARS)
-
-        ret.seed = ''
-        return ret
+    def get_hard_presets() -> Settings:
+        return Settings.from_preset_file(PRESETS_PATH / 'hard.preset.json')
 
     @staticmethod
     def get_tourney_early_preset() -> Settings:
-        '''
-        Settings for tourney up to Ro8.
-        '''
-        ret = Settings()
-
-        ret.item_difficulty = Difficulty.NORMAL
-        ret.enemy_difficulty = Difficulty.NORMAL
-        ret.shopprices = ShopPrices.NORMAL
-        ret.techorder = TechOrder.FULL_RANDOM
-
-        GF = GameFlags
-
-        ret.gameflags = (
-            GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT | GF.BOSS_RANDO |
-            GF.BOSS_SPOT_HP | GF.FAST_TABS | GF.FREE_MENU_GLITCH |
-            GF.GEAR_RANDO | GF.HEALING_ITEM_RANDO
-        )
-
-        return ret
+        '''Settings for tourney up to Ro8.'''
+        return Settings.from_preset_file(PRESETS_PATH / 'catalack-cup.preset.json')
 
     @staticmethod
     def get_tourney_top8_preset() -> Settings:
-        ret = Settings.get_tourney_early_preset()
-
-        ret.item_difficulty = Difficulty.HARD
-        ret.gameflags &= ~GameFlags.FREE_MENU_GLITCH
-
-        return ret
+        return Settings.from_preset_file(PRESETS_PATH / 'catalack-cup-top8.preset.json')
 
     def get_flag_diffs(self) -> Tuple[GameFlags, GameFlags]:
         '''Get diff from initial flags (+, -).'''

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from enum import Flag, IntEnum, auto
-from dataclasses import dataclass, field
-from typing import Callable, Union, Optional, Tuple, Type, TypeVar
+from dataclasses import dataclass, field, fields
+from typing import Any, Callable, Dict, List, Union, Mapping, Optional, Sequence, Tuple, Type, TypeVar
 
 import bossrandotypes as rotypes
 import ctoptions
 
+JSONPrimitive = Optional[Union[int, float, bool, str]]
+JSONType = Union[JSONPrimitive, Mapping[str, "JSONType"], Sequence["JSONType"]]
 SIE = TypeVar('SIE', bound='StrIntEnum')
 
 
@@ -195,11 +197,11 @@ _forced_on_dict = {
 }
 
 
-def get_forced_off(flag: GameFlags) -> GameFlags:
+def get_forced_off(flag: Union[GameFlags, GameMode]) -> GameFlags:
     return _forced_off_dict.get(flag, GameFlags(0))
 
 
-def get_forced_on(flag: GameFlags) -> GameFlags:
+def get_forced_on(flag: Union[GameFlags, GameMode]) -> GameFlags:
     return _forced_on_dict.get(flag, GameFlags(0))
 
 

--- a/sourcefiles/scriptshortener.py
+++ b/sourcefiles/scriptshortener.py
@@ -5,10 +5,8 @@ import ctrom
 import ctenums
 
 import eventcommand
-import eventfunction
 
-from ctevent import CommandNotFoundException
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
+from eventcommand import EventCommand as EC, FuncSync as FS
 from eventfunction import EventFunction as EF
 
 

--- a/sourcefiles/shops/shoptypes.py
+++ b/sourcefiles/shops/shoptypes.py
@@ -106,7 +106,7 @@ class ShopManager:
         '''Print out all shops with prices from item_db.'''
         print(self.get_spoiler_string(item_db))
 
-    def _jot_json(self):
+    def to_jot_json(self):
         shops_ignored = [
             ctenums.ShopID.EMPTY_12, ctenums.ShopID.EMPTY_14,
             ctenums.ShopID.LAST_VILLAGE_UPDATED

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -3,7 +3,7 @@ import math
 import random
 from typing import Callable
 
-import ctenums, ctstrings
+import ctstrings
 import cttechtypes as ctt
 import techdb
 

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -1,7 +1,7 @@
 """Module to randomize tech damage based on assigned mp."""
 import math
 import random
-from typing import Callable
+from typing import Callable, Dict, Union
 
 import ctstrings
 import cttechtypes as ctt
@@ -111,7 +111,7 @@ def modify_effect_header(
     """
 
     # Sketchy math was performed to come up with these.
-    scale_dict: dict[ctt.DamageFormula, Callable[[int], int]] = {
+    scale_dict: Dict[ctt.DamageFormula, Callable[[int], Union[int, float]]] = {
         ctt.DamageFormula.MAGIC: lambda mp: 1.88*mp+4.34,
         ctt.DamageFormula.PC_MELEE: lambda mp: math.sqrt(55.6*mp + 65.8),
         ctt.DamageFormula.PC_AYLA: lambda mp: math.sqrt(62.6*mp + 134),

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -125,4 +125,3 @@ def modify_effect_header(
     scale_function = scale_dict[formula_type]
     scale_factor = scale_function(new_mp)/scale_function(orig_mp)
     effect_header.power = round(scale_factor*effect_header.power)
-

--- a/sourcefiles/techdb.py
+++ b/sourcefiles/techdb.py
@@ -4,7 +4,6 @@
 #    from hardcoded loop bounds.
 
 from __future__ import annotations
-import copy
 from typing import Optional
 import typing
 
@@ -14,8 +13,7 @@ from byteops import get_record, set_record, \
 import ctenums
 import ctrom
 import ctstrings
-from cttypes import BinaryData, SizedBinaryData
-import cttypes
+from cttypes import SizedBinaryData
 import cttechtypes as ctt
 import pctech
 from techrefs import fix_tech_refs

--- a/sourcefiles/tests/conftest.py
+++ b/sourcefiles/tests/conftest.py
@@ -1,6 +1,17 @@
 import sys
 
 from pathlib import Path
+from typing import Dict
+
+import pytest
 
 # add sourcefiles to import search path
 sys.path.append(str(Path(__file__).parent.parent))
+
+
+@pytest.fixture(scope='session')
+def paths() -> Dict[str, Path]:
+    paths = {'tests': Path(__file__).parent.resolve()}
+    paths['sourcefiles'] = Path(paths['tests'].parent.resolve())
+    paths['presets'] = paths['sourcefiles'] / 'presets'
+    return paths

--- a/sourcefiles/tests/requirements.txt
+++ b/sourcefiles/tests/requirements.txt
@@ -1,2 +1,3 @@
 flake8>=6.1,<7.0
 pytest>=7.4,<8.0
+pytest-cov>=4.1,<5.0

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
 import pytest
 
 import arguments
+import randosettings as rset
 
-from randosettings import CosmeticFlags as CF, GameFlags as GF
+from randosettings import CosmeticFlags as CF, GameFlags as GF, GameMode as GM
 
 
 @pytest.fixture(scope='session')
@@ -11,23 +13,80 @@ def parser():
 
 
 @pytest.mark.parametrize(
-    'cli_args, init, expected_flags',
+    'cli_args, expected_settings',
     [
-        (['--fix-glitch', '--zeal-end', '--fast-pendant'], GF(0), GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT),
-        (['--autorun', '--reduce-flashes'], CF(0), CF.AUTORUN | CF.REDUCE_FLASH),
+        (
+            [],
+            {
+                'game_mode': GM.STANDARD,
+                'item_difficulty': rset.Difficulty.NORMAL,
+                'techorder': rset.TechOrder.FULL_RANDOM,
+            },
+        ),
+        (
+            [
+                '--mode',
+                'loc',
+                '--boss-randomization',
+                '--char-rando',
+                '--gear-rando',
+                '--zenan-alt-music',
+                '--item-difficulty',
+                'hard',
+                '--enemy-difficulty',
+                'hard',
+                '--tech-order',
+                'balanced',
+                '--shop-prices',
+                'free',
+            ],
+            {
+                'game_mode': GM.LEGACY_OF_CYRUS,
+                'gameflags': GF.BOSS_RANDO | GF.CHAR_RANDO | GF.GEAR_RANDO,
+                'cosmetic_flags': CF.ZENAN_ALT_MUSIC,
+                'item_difficulty': rset.Difficulty.HARD,
+                'enemy_difficulty': rset.Difficulty.HARD,
+                'techorder': rset.TechOrder.BALANCED_RANDOM,
+                'shopprices': rset.ShopPrices.FREE,
+            },
+        ),
+    ],
+    ids=('defaults', 'complex'),
+)
+def test_args_to_settings(cli_args, expected_settings, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    settings = arguments.args_to_settings(args)
+
+    assert settings
+    assert isinstance(settings, rset.Settings), f"Wrong type for settings: {type(settings)}"
+
+    for attr, value in expected_settings.items():
+        assert getattr(settings, attr) == value
+
+
+@pytest.mark.parametrize(
+    'cli_args, cls, init, expected_flags',
+    [
+        (
+            ['--fix-glitch', '--zeal-end', '--fast-pendant'],
+            arguments.GameFlagsAdapter,
+            None,
+            GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT,
+        ),
+        (['--autorun', '--reduce-flashes'], arguments.CosmeticFlagsAdapter, None, CF.AUTORUN | CF.REDUCE_FLASH),
         (
             ['--chronosanity', '--unlocked-skyways'],
+            arguments.GameFlagsAdapter,
             GF.FIX_GLITCH | GF.FAST_TABS,
             GF.FIX_GLITCH | GF.FAST_TABS | GF.CHRONOSANITY | GF.UNLOCKED_SKYGATES,
         ),
     ],
     ids=('gameflags', 'cosmetic_flags', 'init'),
 )
-def test_fill_flags(cli_args, init, expected_flags, parser):
+def test_flags_adapters(cli_args, cls, init, expected_flags, parser):
     args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
-    val_dict = vars(args)
 
-    flags = arguments.fill_flags(val_dict, init)
+    flags = cls.to_setting(args, init=init)
     expected_type = type(expected_flags)
 
     assert isinstance(flags, expected_type), f"Flags are not expected type: {expected_type}"

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -36,7 +36,7 @@ def parser():
                 'shopprices': rset.ShopPrices.NORMAL,
                 'mystery_settings': rset.MysterySettings(),
                 'tab_settings': rset.TabSettings(),
-                'char_names': rset.CharSettings.default_names(),
+                'char_settings': rset.CharSettings(),
                 'bucket_settings': rset.BucketSettings(),
             },
         ),
@@ -45,7 +45,7 @@ def parser():
             (
                 '--mode loc --boss-randomization --char-rando --gear-rando --zenan-alt-music'
                 ' --item-difficulty hard --enemy-difficulty hard --tech-order balanced'
-                ' --shop-prices free --frog-name Glenn --marle-name Nadia --epoch-name Apoch'
+                ' --shop-prices free'
             ).split(' '),
             {
                 'game_mode': GM.LEGACY_OF_CYRUS,
@@ -55,7 +55,6 @@ def parser():
                 'enemy_difficulty': rset.Difficulty.HARD,
                 'techorder': rset.TechOrder.BALANCED_RANDOM,
                 'shopprices': rset.ShopPrices.FREE,
-                'char_names': ['Crono', 'Nadia', 'Lucca', 'Robo', 'Glenn', 'Ayla', 'Magus', 'Apoch'],
             },
         ),
     ],
@@ -149,7 +148,27 @@ def test_char_choices(cli_args, expected_choices, parser):
     args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
     settings = arguments.args_to_settings(args)
 
-    assert settings.char_choices == expected_choices
+    assert settings.char_settings.choices == expected_choices
+
+
+@pytest.mark.parametrize(
+    'cli_args, expected_names',
+    [
+        # default
+        ([], ['Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch']),
+        # overrides
+        (
+            '--frog-name Glenn --marle-name Nadia --epoch-name Apoch'.split(' '),
+            ['Crono', 'Nadia', 'Lucca', 'Robo', 'Glenn', 'Ayla', 'Magus', 'Apoch'],
+        ),
+    ],
+    ids=('default', 'override'),
+)
+def test_char_names(cli_args, expected_names, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    settings = arguments.args_to_settings(args)
+
+    assert settings.char_settings.names == expected_names
 
 
 @pytest.mark.parametrize(

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -34,10 +34,10 @@ def parser():
                 'enemy_difficulty': rset.Difficulty.NORMAL,
                 'techorder': rset.TechOrder.FULL_RANDOM,
                 'shopprices': rset.ShopPrices.NORMAL,
-                # 'mystery_settings': rset.MysterySettings(),
-                # 'tab_settings': rset.TabSettings(),
+                'mystery_settings': rset.MysterySettings(),
+                'tab_settings': rset.TabSettings(),
                 'char_names': rset.CharSettings.default_names(),
-                # 'bucket_settings': rset.BucketSettings(),
+                'bucket_settings': rset.BucketSettings(),
             },
         ),
         # overriding most non-flag settings
@@ -71,7 +71,6 @@ def test_args_to_settings(cli_args, expected_settings, parser):
         assert getattr(settings, attr) == value
 
 
-@pytest.mark.xfail(reason='bucket flags missing/broken in CLI')
 @pytest.mark.parametrize(
     'cli_args, expected',
     [
@@ -238,7 +237,6 @@ def test_ro_settings():
     assert False
 
 
-@pytest.mark.xfail(reason='mystery flags missing/broken in CLI')
 @pytest.mark.parametrize(
     'cli_args, expected',
     [
@@ -316,7 +314,6 @@ def test_mystery_settings(cli_args, expected, parser):
     assert mystery == expected
 
 
-@pytest.mark.xfail(reason='tab flags missing/broken in CLI')
 @pytest.mark.parametrize(
     'cli_args, expected',
     [

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -1,0 +1,34 @@
+import pytest
+
+import arguments
+
+from randosettings import CosmeticFlags as CF, GameFlags as GF
+
+
+@pytest.fixture(scope='session')
+def parser():
+    return arguments.get_parser()
+
+
+@pytest.mark.parametrize(
+    'cli_args, init, expected_flags',
+    [
+        (['--fix-glitch', '--zeal-end', '--fast-pendant'], GF(0), GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT),
+        (['--autorun', '--reduce-flashes'], CF(0), CF.AUTORUN | CF.REDUCE_FLASH),
+        (
+            ['--chronosanity', '--unlocked-skyways'],
+            GF.FIX_GLITCH | GF.FAST_TABS,
+            GF.FIX_GLITCH | GF.FAST_TABS | GF.CHRONOSANITY | GF.UNLOCKED_SKYGATES,
+        ),
+    ],
+    ids=('gameflags', 'cosmetic_flags', 'init'),
+)
+def test_fill_flags(cli_args, init, expected_flags, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    val_dict = vars(args)
+
+    flags = arguments.fill_flags(val_dict, init)
+    expected_type = type(expected_flags)
+
+    assert isinstance(flags, expected_type), f"Flags are not expected type: {expected_type}"
+    assert flags == expected_flags, 'Flags do not match expected flags'

--- a/sourcefiles/tests/test_jotjson.py
+++ b/sourcefiles/tests/test_jotjson.py
@@ -10,6 +10,9 @@ def settings():
     GF = rset.GameFlags
     settings = rset.Settings()
     settings.gameflags = GF.FIX_GLITCH | GF.EPOCH_FAIL
+    settings.bucket_settings.objectives_win = True
+    settings.char_settings.choices[5] == [5]
+    settings.tab_settings.scheme = scheme = rset.TabRandoScheme.BINOMIAL
     return settings
 
 
@@ -19,6 +22,9 @@ def test_json_encode_settings(settings):
 
 
 def test_json_decode_settings(settings):
-    data = json.dumps({'settings': settings}, cls=jotjson.JOTJSONEncoder)
+    data = json.dumps({'configuration': {'test': 1}, 'settings': settings}, cls=jotjson.JOTJSONEncoder)
     decoded = json.loads(data, cls=jotjson.JOTJSONDecoder)
     assert decoded['settings'] == settings, 'Decoded settings do not match initial settings'
+
+    # for now, we strip configuration out
+    assert 'configuration' not in decoded, 'Unexpected configuration in decoded JSON'

--- a/sourcefiles/tests/test_jotjson.py
+++ b/sourcefiles/tests/test_jotjson.py
@@ -16,3 +16,9 @@ def settings():
 def test_json_encode_settings(settings):
     data = json.dumps(settings, cls=jotjson.JOTJSONEncoder)
     assert data, 'Failed to encode settings into JSON.'
+
+
+def test_json_decode_settings(settings):
+    data = json.dumps({'settings': settings}, cls=jotjson.JOTJSONEncoder)
+    decoded = json.loads(data, cls=jotjson.JOTJSONDecoder)
+    assert decoded['settings'] == settings, 'Decoded settings do not match initial settings'

--- a/sourcefiles/tests/test_jotjson.py
+++ b/sourcefiles/tests/test_jotjson.py
@@ -1,0 +1,18 @@
+import json
+import pytest
+
+import jotjson
+import randosettings as rset
+
+
+@pytest.fixture(scope='session')
+def settings():
+    GF = rset.GameFlags
+    settings = rset.Settings()
+    settings.gameflags = GF.FIX_GLITCH | GF.EPOCH_FAIL
+    return settings
+
+
+def test_json_encode_settings(settings):
+    data = json.dumps(settings, cls=jotjson.JOTJSONEncoder)
+    assert data, 'Failed to encode settings into JSON.'

--- a/sourcefiles/tests/test_presetimizer.py
+++ b/sourcefiles/tests/test_presetimizer.py
@@ -62,6 +62,18 @@ def test_presetimizer(args, expected, presetimizer):
             assert key not in preset['settings'], f"Unexpected key in preset: '{key}'"
 
 
+def test_presetimizer_metadata(presetimizer):
+    '''Check that JSON data can be passed through presetimizer to set metadata.'''
+    metadata = {'name': 'Presetimizer Test', 'desc': 'Testing presetimizer', 'tags': ['a_tag', 'another_tag']}
+    sp = presetimizer(['--metadata', json.dumps(metadata).strip()])
+    assert sp.returncode == 0, f"Presetimizer issued non-zero exit code: {sp.returncode}"
+
+    stdout = sp.stdout.decode('utf-8')
+    preset = json.loads(stdout)
+
+    assert preset['metadata'] == metadata
+
+
 def test_presetimizer_preset(paths, presetimizer):
     '''Check can pass an input preset to prestimizer, add flags, and load preset into Settings.'''
     preset = paths['presets'] / 'race.preset.json'

--- a/sourcefiles/tests/test_presetimizer.py
+++ b/sourcefiles/tests/test_presetimizer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import jotjson
+from randosettings import GameFlags as GF
+
+
+@pytest.fixture
+def presetimizer(paths):
+    script = paths['sourcefiles'] / 'presetimizer.py'
+
+    def _sp(args):
+        return subprocess.run([script] + args, stdout=subprocess.PIPE, cwd=str(paths['sourcefiles']))
+
+    return _sp
+
+
+@pytest.mark.parametrize(
+    'args, expected',
+    [
+        # make sure certain keys always show up in preset, regardless if explicilty set
+        ([], []),
+        # gameflags should only be in preset when there is at least one
+        ('--mode loc -gzpmq -ef -cr -rc'.split(' '), ['gameflags']),
+        # bucket_settings should only be in preset when used
+        (
+            '-k -obj1=Random -obj2=boss_nogo -obj3=recruit_3'.split(' '),
+            ['gameflags', 'bucket_settings'],
+        ),
+        # char_settings should only be in preset when at least one char choice is made
+        (['--crono-choices=not crono'], ['char_settings']),
+        # mystery_settings should only be in preset when mystery flag is used
+        (['--mystery'], ['gameflags', 'mystery_settings']),
+        # tab_settings should only be in preset when a tab option is specified
+        (['--max-power-tab=6'], ['tab_settings']),
+    ],
+    ids=('default', 'gameflags', 'bucket', 'char', 'mystery', 'tab'),
+)
+def test_presetimizer(args, expected, presetimizer):
+    '''Check presetimizer output only includes expected settings.'''
+    sp = presetimizer(args)
+    assert sp.returncode == 0, f"Presetimizer issued non-zero exit code: {sp.returncode}"
+
+    stdout = sp.stdout.decode('utf-8')
+    preset = json.loads(stdout)
+    assert preset, 'Empty preset'
+
+    # these should always be included in a preset, regardless if explicitly passed
+    always = ['game_mode', 'item_difficulty', 'enemy_difficulty', 'techorder', 'shopprices']
+    # make sure expected keys are in settings
+    for key in always + expected:
+        assert key in preset['settings'], f"Missing expected key in preset: '{key}'"
+
+    # make sure these only show up when explicit
+    optional = ['gameflags', 'char_settings', 'bucket_settings', 'mystery_settings', 'tab_settings']
+    for key in optional:
+        if key not in expected:
+            assert key not in preset['settings'], f"Unexpected key in preset: '{key}'"
+
+
+def test_presetimizer_preset(paths, presetimizer):
+    '''Check can pass an input preset to prestimizer, add flags, and load preset into Settings.'''
+    preset = paths['presets'] / 'race.preset.json'
+    sp = presetimizer(['-i', str(preset), '-cr', '--ayla-choices=ayla'])
+    assert sp.returncode == 0, f"Presetimizer issued non-zero exit code: {sp.returncode}"
+
+    stdout = sp.stdout.decode('utf-8')
+    preset = json.loads(stdout, cls=jotjson.JOTJSONDecoder)['settings']
+
+    assert preset.char_settings.choices[5] == [5]
+    assert GF.CHRONOSANITY in preset.gameflags

--- a/sourcefiles/tests/test_randosettings.py
+++ b/sourcefiles/tests/test_randosettings.py
@@ -1,4 +1,7 @@
 import pytest
+from pathlib import Path
+from typing import List
+
 import randosettings as rset
 
 from randosettings import GameFlags as _GF
@@ -9,6 +12,12 @@ ALL_KI_FLAGS: rset.GameFlags = _GF.RESTORE_JOHNNY_RACE | _GF.RESTORE_TOOLS | _GF
 MOST_SPOT_FLAGS: rset.GameFlags = _GF.ADD_BEKKLER_SPOT | _GF.ADD_CYRUS_SPOT | _GF.ADD_OZZIE_SPOT | _GF.ADD_RACELOG_SPOT
 
 # FIXTURES ###################################################################
+
+
+@pytest.fixture(scope='session')
+def presets(paths) -> List[Path]:
+    '''All preset JSON files.'''
+    return [path for path in paths['presets'].rglob('*.preset.json')]
 
 
 @pytest.fixture(scope='function')
@@ -145,3 +154,15 @@ def test_fix_flag_conflicts_unfixable(settings):
     with pytest.raises(ValueError) as ex:
         settings.fix_flag_conflicts()
     assert 'fix flag conflicts' in str(ex)
+
+
+def test_settings_from_preset_file(presets):
+    '''Check all .preset.json files in sourcefiles/presets can be parsed into Settings.'''
+    assert presets, 'Failed to find any .preset.json files'
+
+    for preset in presets:
+        settings = rset.Settings.from_preset_file(preset)
+        assert settings
+
+        # assure all presets have glitch fixes and fast tabs
+        assert settings.gameflags & (_GF.FIX_GLITCH | _GF.FAST_TABS)

--- a/sourcefiles/treasures/delete_treasurewriter.py
+++ b/sourcefiles/treasures/delete_treasurewriter.py
@@ -25,7 +25,7 @@ class Treasure(abc.ABC):
     def __init__(self, reward: RewardType = ctenums.ItemID.MOP):
         self.reward = reward
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.reward)
 
     @abc.abstractmethod

--- a/sourcefiles/treasures/delete_treasurewriter.py
+++ b/sourcefiles/treasures/delete_treasurewriter.py
@@ -8,16 +8,12 @@ import abc
 import typing
 
 import byteops
-import ctevent
 import ctenums
 import ctrom
 import cttypes as ctt
 
-import eventcommand
-import eventfunction
 
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
-from eventfunction import EventFunction as EF
+from eventcommand import EventCommand as EC
 
 
 RewardType = typing.Union[ctenums.ItemID, int]

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -17,10 +17,8 @@ import ctstrings
 import cttypes as ctt
 
 import eventcommand
-import eventfunction
 
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
-from eventfunction import EventFunction as EF
+from eventcommand import EventCommand as EC
 
 
 RewardType = typing.Union[ctenums.ItemID, int]

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -31,7 +31,7 @@ class Treasure(abc.ABC):
     def __init__(self, reward: RewardType = ctenums.ItemID.MOP):
         self.reward = reward
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.reward)
 
     @abc.abstractmethod

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -276,7 +276,7 @@ class ScriptTreasure(Treasure):
             reward: RewardType,
             orig_gold_amt: typing.Optional[int] = None):
 
-        if type(reward) == ctenums.ItemID:
+        if isinstance(reward, ctenums.ItemID):
             if reward == ctenums.ItemID.NONE:
                 repl_str = 'Nothing'
             else:

--- a/sourcefiles/treasures/treasurewriter.py
+++ b/sourcefiles/treasures/treasurewriter.py
@@ -272,4 +272,3 @@ def find_script_ptrs(ptr_list):
         chest_index = (ptr-0x35f404)//4
         if 0 > chest_index or chest_index > 0xF8:
             print(f"{ptr:06X}")
-

--- a/sourcefiles/treasures/treasurewriter.py
+++ b/sourcefiles/treasures/treasurewriter.py
@@ -231,7 +231,7 @@ def ptr_to_enum(ptr_list):
     tdict = config.treasure_assign_dict
 
     treasureids = [x for x in tdict.keys()
-                   if type(tdict[x]) == cfg.ChestTreasure
+                   if isinstance(tdict[x], cfg.ChestTreasure)
                    and tdict[x].chest_index in chestid]
 
     used_ids = [tdict[x].chest_index for x in treasureids]


### PR DESCRIPTION
The intention of this PR is to add the ability to import re-usable JSON preset files for Jets of Time in a way that works with the randomizer CLI and provides a clean interface for use in the ctjot web GUI (which was concurrently tested with these changes on TBD branch).

This support was developed in a semi-test-driven way, which ended up uncovering several bugs in the CLI (via adding tests that failed), which this PR also addresses. This PR ends up being a relatively large, but low-risk refactoring of the CLI.

## Updates

### User-Facing

* TBD

### Developer-Facing

* Added test coverage for a lot in `arguments.py` which ends up covering around 28% of the entire code base (from `pytest --cov` reporting)
* The char names and choices have been combined into a `CharSettings` dataclass, similar to handling of bucket objectives and mystery setttings
* 